### PR TITLE
Exit with failure when unnecessarily specifying `--ignore-dep` CLI option

### DIFF
--- a/bin/check-dependency-version-consistency.ts
+++ b/bin/check-dependency-version-consistency.ts
@@ -6,6 +6,7 @@ import { readFileSync } from 'fs';
 import {
   calculateVersionsForEachDependency,
   calculateMismatchingVersions,
+  filterOutIgnoredDependencies,
 } from '../lib/dependency-versions';
 import { mismatchingVersionsToOutputLines } from '../lib/output';
 import { join } from 'path';
@@ -32,11 +33,11 @@ program
     collect,
     []
   )
-  .action(function (path, options) {
+  .action(function (path, options: { ignoreDep: string[] }) {
     // Calculate.
     const dependencyVersions = calculateVersionsForEachDependency(path);
-    const mismatchingVersions = calculateMismatchingVersions(
-      dependencyVersions,
+    const mismatchingVersions = filterOutIgnoredDependencies(
+      calculateMismatchingVersions(dependencyVersions),
       options.ignoreDep
     );
 

--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -101,16 +101,11 @@ function recordDependencyVersion(
 }
 
 export function calculateMismatchingVersions(
-  dependencyVersions: DependenciesToVersionsSeen,
-  ignoreDeps: string[] = []
+  dependencyVersions: DependenciesToVersionsSeen
 ): MismatchingDependencyVersions {
   return [...dependencyVersions.keys()]
     .sort()
     .map((dependency) => {
-      if (ignoreDeps.includes(dependency)) {
-        return undefined;
-      }
-
       const versionList = dependencyVersions.get(dependency);
       /* istanbul ignore if */
       if (!versionList) {
@@ -133,4 +128,26 @@ export function calculateMismatchingVersions(
       return undefined;
     })
     .filter((obj) => obj !== undefined) as MismatchingDependencyVersions;
+}
+
+export function filterOutIgnoredDependencies(
+  mismatchingVersions: MismatchingDependencyVersions,
+  ignoredDependencies: string[]
+): MismatchingDependencyVersions {
+  ignoredDependencies.forEach((ignoreDependency) => {
+    if (
+      !mismatchingVersions.some(
+        (mismatchingVersion) =>
+          mismatchingVersion.dependency === ignoreDependency
+      )
+    ) {
+      throw new Error(
+        `Specified option '--ignore-dep ${ignoreDependency}', but no mismatches detected.`
+      );
+    }
+  });
+  return mismatchingVersions.filter(
+    (mismatchingVersion) =>
+      !ignoredDependencies.includes(mismatchingVersion.dependency)
+  );
 }

--- a/test/lib/dependency-versions.ts
+++ b/test/lib/dependency-versions.ts
@@ -2,8 +2,9 @@ import 'mocha'; // eslint-disable-line import/no-unassigned-import -- to get Moc
 import {
   calculateVersionsForEachDependency,
   calculateMismatchingVersions,
+  filterOutIgnoredDependencies,
 } from '../../lib/dependency-versions';
-import { deepStrictEqual } from 'assert';
+import { deepStrictEqual, throws } from 'assert';
 import {
   FIXTURE_PATH_VALID,
   FIXTURE_PATH_INCONSISTENT_VERSIONS,
@@ -55,30 +56,6 @@ describe('Utils | dependency-versions', function () {
       ]);
     });
 
-    it('has mismatches with fixture with inconsistent versions and one dependency ignored', function () {
-      const dependencyVersions = calculateVersionsForEachDependency(
-        FIXTURE_PATH_INCONSISTENT_VERSIONS
-      );
-      deepStrictEqual(
-        calculateMismatchingVersions(dependencyVersions, ['baz']),
-        [
-          {
-            dependency: 'foo',
-            versions: [
-              {
-                count: 2,
-                version: '1.2.0',
-              },
-              {
-                count: 1,
-                version: '1.3.0',
-              },
-            ],
-          },
-        ]
-      );
-    });
-
     it('has empty results when no packages', function () {
       const dependencyVersions = calculateVersionsForEachDependency(
         FIXTURE_PATH_NO_PACKAGES
@@ -98,6 +75,45 @@ describe('Utils | dependency-versions', function () {
         FIXTURE_PATH_PACKAGE_MISSING_PACKAGE_JSON
       );
       deepStrictEqual(calculateMismatchingVersions(dependencyVersions), []);
+    });
+  });
+
+  describe('#filterOutIgnoredDependencies', function () {
+    it('filters out an ignored dependency', function () {
+      const dependencyVersions = calculateMismatchingVersions(
+        calculateVersionsForEachDependency(FIXTURE_PATH_INCONSISTENT_VERSIONS)
+      );
+      deepStrictEqual(
+        filterOutIgnoredDependencies(dependencyVersions, ['foo']),
+        [
+          {
+            dependency: 'baz',
+            versions: [
+              {
+                count: 1,
+                version: '^7.8.9',
+              },
+              {
+                count: 1,
+                version: '^8.0.0',
+              },
+            ],
+          },
+        ]
+      );
+    });
+
+    it('throws when unnecessarily ignoring a dependency that has no mismatches', function () {
+      const dependencyVersions = calculateMismatchingVersions(
+        calculateVersionsForEachDependency(FIXTURE_PATH_INCONSISTENT_VERSIONS)
+      );
+      throws(
+        () =>
+          filterOutIgnoredDependencies(dependencyVersions, ['nonexistentDep']),
+        new Error(
+          "Specified option '--ignore-dep nonexistentDep', but no mismatches detected."
+        )
+      );
     });
   });
 });


### PR DESCRIPTION
Passing `--ignore-dep foo` as a CLI option should be avoided when there's no need to ignore the dependency (because the dependency has no version mismatches).

```
check-dependency-version-consistency --ignore-dep foo
```