### PR TITLE
Implement autofixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ sinon has more than one version: ^1.17.7 (1 usage), ^9.0.3 (3 usages)
 
 | Name | Description |
 | --- | --- |
+| `--fix` | Whether to autofix inconsistencies (using highest version present). |
 | `--ignore-dep` | Dependency to ignore mismatches for (option can be repeated). |
 
 ## Related

--- a/package.json
+++ b/package.json
@@ -40,11 +40,16 @@
   },
   "dependencies": {
     "commander": "^8.1.0",
+    "edit-json-file": "^1.6.0",
+    "semver": "^7.3.5",
     "type-fest": "^2.1.0"
   },
   "devDependencies": {
+    "@types/edit-json-file": "^1.6.0",
     "@types/mocha": "^9.0.0",
+    "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.0.0",
+    "@types/semver": "^7.3.8",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "eslint": "^7.0.0",
@@ -52,6 +57,7 @@
     "eslint-plugin-square": "^20.0.2",
     "markdownlint-cli": "^0.28.1",
     "mocha": "^9.1.1",
+    "mock-fs": "^5.0.0",
     "npm-package-json-lint": "^5.2.3",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",

--- a/test/lib/dependency-versions.ts
+++ b/test/lib/dependency-versions.ts
@@ -3,8 +3,10 @@ import {
   calculateVersionsForEachDependency,
   calculateMismatchingVersions,
   filterOutIgnoredDependencies,
+  fixMismatchingVersions,
+  compareRanges,
 } from '../../lib/dependency-versions.js';
-import { deepStrictEqual, throws } from 'node:assert';
+import { strictEqual, deepStrictEqual, throws } from 'node:assert';
 import {
   FIXTURE_PATH_VALID,
   FIXTURE_PATH_INCONSISTENT_VERSIONS,
@@ -12,6 +14,9 @@ import {
   FIXTURE_PATH_NO_DEPENDENCIES,
   FIXTURE_PATH_PACKAGE_MISSING_PACKAGE_JSON,
 } from '../fixtures/index.js';
+import mockFs from 'mock-fs';
+import { readFileSync } from 'node:fs';
+import type { PackageJson } from 'type-fest';
 
 describe('Utils | dependency-versions', function () {
   describe('#calculateMismatchingVersions', function () {
@@ -112,6 +117,126 @@ describe('Utils | dependency-versions', function () {
         new Error(
           "Specified option '--ignore-dep nonexistentDep', but no mismatches detected."
         )
+      );
+    });
+  });
+
+  describe('#fixMismatchingVersions', function () {
+    beforeEach(function () {
+      // Create a mock workspace filesystem for temporary usage in this test because changes will be written to some files.
+      mockFs({
+        'package.json': '{"workspaces": ["scope1/*"]}',
+        'scope1/package1': {
+          'package.json':
+            '{"dependencies": {"foo": "^1.0.0", "bar": "^3.0.0" }}',
+        },
+        'scope1/package2': {
+          'package.json':
+            '{"dependencies": {"foo": "^2.0.0", "bar": "invalidVersion" }}',
+        },
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('fixes the fixable inconsistencies', function () {
+      const mismatchingVersions = calculateMismatchingVersions(
+        calculateVersionsForEachDependency('.')
+      );
+      const fixedMismatchingVersions = fixMismatchingVersions(
+        '.',
+        mismatchingVersions
+      );
+
+      const packageJson1: PackageJson = JSON.parse(
+        readFileSync('scope1/package1/package.json', 'utf-8')
+      );
+      const packageJson2: PackageJson = JSON.parse(
+        readFileSync('scope1/package2/package.json', 'utf-8')
+      );
+
+      strictEqual(
+        packageJson1.dependencies && packageJson1.dependencies.foo,
+        '^2.0.0',
+        'updates the package1 `foo` version to the highest version'
+      );
+      strictEqual(
+        packageJson1.dependencies && packageJson1.dependencies.bar,
+        '^3.0.0',
+        'does not change package1 `bar` version due to abnormal version present'
+      );
+      strictEqual(
+        packageJson2.dependencies && packageJson2.dependencies.foo,
+        '^2.0.0',
+        'does not change package1 `foo` version since already at highest version'
+      );
+      strictEqual(
+        packageJson2.dependencies && packageJson2.dependencies.bar,
+        'invalidVersion',
+        'does not change package1 `bar` version due to abnormal version present'
+      );
+
+      deepStrictEqual(
+        fixedMismatchingVersions,
+        [
+          {
+            dependency: 'bar',
+            versions: [
+              {
+                count: 1,
+                version: '^3.0.0',
+              },
+              {
+                count: 1,
+                version: 'invalidVersion',
+              },
+            ],
+          },
+        ],
+        'should return only the dependency that could not be fixed due to the abnormal version present'
+      );
+    });
+  });
+
+  describe('#compareRanges', function () {
+    it('correctly chooses the higher range', function () {
+      // 1 (greater than)
+      strictEqual(compareRanges('1.2.3', '1.2.2'), 1);
+      strictEqual(compareRanges('5.0.0', '4.0.0'), 1);
+      strictEqual(compareRanges('8.0.0-beta.1', '^7'), 1);
+      strictEqual(compareRanges('^5.0.0', '4.0.0'), 1);
+      strictEqual(compareRanges('^5.0.0', '^4.0.0'), 1);
+      strictEqual(compareRanges('^5.0.0', '~4.0.0'), 1);
+      strictEqual(compareRanges('^5.0.0', '~5.0.0'), 1);
+      strictEqual(compareRanges('~5.0.0', '5.0.0'), 1);
+      strictEqual(compareRanges('~5.0.0', '~4.0.0'), 1);
+
+      // -1 (less than)
+      strictEqual(compareRanges('4.0.0', '5.0.0'), -1);
+      strictEqual(compareRanges('5.0.0', '~5.0.0'), -1);
+      strictEqual(compareRanges('^4.0.0', '^5.0.0'), -1);
+      strictEqual(compareRanges('~4.0.0', '~5.0.0'), -1);
+      strictEqual(compareRanges('~5.0.0', '^5.0.0'), -1);
+
+      // 0 (equal)
+      strictEqual(compareRanges('6', '6'), 0);
+      strictEqual(compareRanges('6.0', '6.0'), 0);
+      strictEqual(compareRanges('6.0.0', '6.0.0'), 0);
+      strictEqual(compareRanges('^6.0.0', '^6.0.0'), 0);
+      strictEqual(compareRanges('v6', '6'), 0);
+      strictEqual(compareRanges('~6.0.0', '~6.0.0'), 0);
+    });
+
+    it('throws with invalid ranges', function () {
+      throws(
+        () => compareRanges('foo', '~6.0.0'),
+        new Error('Invalid Version: foo')
+      );
+      throws(
+        () => compareRanges('~6.0.0', 'foo'),
+        new Error('Invalid Version: foo')
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,6 +460,13 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/edit-json-file@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@types/edit-json-file/-/edit-json-file-1.6.0.tgz#5418ad4dcb96549cc79c56f97f4cfd00389a96e7"
+  integrity sha512-UbxkTXHRQOJuATi+EwR3JlYcbeX14dLH7s1ax8bwucey1CwJ+sXOnkD8ZZXTXHanNvS4xC8DPGDtrDssCpGjNw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
@@ -512,6 +519,13 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.0.0.tgz#3205bcd15ada9bc681ac20bef64e9e6df88fd297"
   integrity sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
 
+"@types/mock-fs@^4.13.1":
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/@types/mock-fs/-/mock-fs-4.13.1.tgz#9201554ceb23671badbfa8ac3f1fa9e0706305be"
+  integrity sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^16.0.0":
   version "16.7.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
@@ -533,6 +547,11 @@
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
+
+"@types/semver@^7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
 
 "@types/unist@*", "@types/unist@^2.0.2":
   version "2.0.6"
@@ -1528,6 +1547,17 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+edit-json-file@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/edit-json-file/-/edit-json-file-1.6.0.tgz#ff51a1648e40ab7613c912f33a2d1079d9b03f63"
+  integrity sha512-m2l38nUbRLxE4rfKC03PYujSGsjpGlF9PyenteiT/rXCGdk7CVoSS2BJEiGUBoAPfGSsiZv8yA5x81WAoQJbuQ==
+  dependencies:
+    find-value "^1.0.3"
+    iterate-object "^1.3.2"
+    r-json "^1.2.5"
+    set-value "^3.0.1"
+    w-json "^1.3.5"
+
 electron-to-chromium@^1.3.811:
   version "1.3.823"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.823.tgz#ebcc606e6e0c08f92e553276711dc30a7ea43c02"
@@ -2123,6 +2153,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+find-value@^1.0.3:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/find-value/-/find-value-1.0.12.tgz#68b6cec84e5b2d51272965e0bf09b26c9159c26e"
+  integrity sha512-OCpo8LTk8eZ2sdDCwbU2Lc3ivYsdM6yod6jP2jHcNEFcjPhkgH0+POzTIol7xx1LZgtbI5rkO5jqxsG5MWtPjQ==
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -2825,6 +2860,13 @@ is-plain-obj@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
+is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
+
 is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
@@ -2906,6 +2948,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.0.0-alpha.1:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
@@ -2966,6 +3013,11 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterate-object@^1.3.2:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/iterate-object/-/iterate-object-1.3.4.tgz#fa50b1d9e58e340a7dd6b4c98c8a5e182e790096"
+  integrity sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -3574,6 +3626,11 @@ mocha@^9.1.1:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
+
+mock-fs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.0.0.tgz#5574520ac824c01a10091bf951c66f677c71acaa"
+  integrity sha512-A5mm/SpSDwwc/klSaEvvKMGQQtiGiQy8UcDAd/vpVO1fV+4zaHjt39yKgCSErFzv2zYxZIUx9Ud/7ybeHBf8Fg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -4291,6 +4348,11 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+r-json@^1.2.5:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/r-json/-/r-json-1.2.10.tgz#62a73d9cafa7eabf670e5c2812c27bdb220a968b"
+  integrity sha512-hu9vyLjSlHXT62NAS7DjI9WazDlvjN0lgp3n431dCVnirVcLkZIpzSwA3orhZEKzdDD2jqNYI+w0yG0aFf4kpA==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -4687,6 +4749,13 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-value@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
+  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
+  dependencies:
+    is-plain-object "^2.0.4"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -5348,6 +5417,11 @@ validate-peer-dependencies@^1.0.0:
   dependencies:
     resolve-package-path "^3.1.0"
     semver "^7.3.2"
+
+w-json@^1.3.5:
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/w-json/-/w-json-1.3.10.tgz#ac448a19ca22376e2753a684b52369c7b1e83313"
+  integrity sha512-XadVyw0xE+oZ5FGApXsdswv96rOhStzKqL53uSe5UaTadABGkWIg1+DTx8kiZ/VqTZTBneoL0l65RcPe4W3ecw==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Running with `--fix` will fix inconsistencies in package versions across a workspace. It will use the highest version range detected for each dependency.

Example:

package1/package.json: fooDependency@^2.0.0
package2/package.json: fooDependency@^3.0.0

The fixer will update the files to:

package1/package.json: fooDependency@^3.0.0
package2/package.json: fooDependency@^3.0.0