### PR TITLE
Sort mismatching version output by version number

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,4 +1,5 @@
 import type { MismatchingDependencyVersions } from './dependency-versions.js';
+import { compareRanges } from './dependency-versions.js';
 
 export function mismatchingVersionsToOutputLines(
   mismatchingDependencyVersions: MismatchingDependencyVersions
@@ -6,6 +7,7 @@ export function mismatchingVersionsToOutputLines(
   return mismatchingDependencyVersions.map(
     (obj) =>
       `${obj.dependency} has more than one version: ${obj.versions
+        .sort((a, b) => compareRanges(a.version, b.version))
         .map(
           (versionObj) =>
             `${versionObj.version} (${versionObj.count} ${pluralizeUsage(

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -17,14 +17,23 @@ describe('Utils | output', function () {
           {
             dependency: 'bar',
             versions: [
-              { version: '1.4.0', count: 3 },
               { version: '2.0.0', count: 4 },
+              { version: '1.4.0', count: 3 },
+            ],
+          },
+          {
+            dependency: 'baz',
+            versions: [
+              { version: '^2.0.0', count: 1 },
+              { version: '~2.0.0', count: 1 },
+              { version: '^1.0.0', count: 1 },
             ],
           },
         ]),
         [
           'foo has more than one version: 1.2.3 (1 usage), 4.5.6 (2 usages)',
           'bar has more than one version: 1.4.0 (3 usages), 2.0.0 (4 usages)',
+          'baz has more than one version: ^1.0.0 (1 usage), ~2.0.0 (1 usage), ^2.0.0 (1 usage)',
         ]
       );
     });


### PR DESCRIPTION
Sort output when displaying list of inconsistent versions found in workspace.

Before:

```
eslint-plugin-node has more than one version: ^10.0.0 (1 usage), ^8.0.0 (3 usages)
```

After: 

```
eslint-plugin-node has more than one version: ^8.0.0 (3 usages), ^10.0.0 (1 usage)
```
