### PR TITLE
Improve output formatting for mismatched versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ If there are any dependency mismatches, the program will exit with failure and o
 
 ```pt
 eslint has more than one version:
-	^7.8.9 (1 usage)
-	^8.0.0 (1 usage)
+    ^7.8.9 (1 usage)
+    ^8.0.0 (1 usage)
 sinon has more than one version:
-	1.2.0 (2 usages)
-	1.3.0 (1 usage)
+    1.2.0 (2 usages)
+    1.3.0 (1 usage)
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ If there are no dependency mismatches, the program will exit with success.
 If there are any dependency mismatches, the program will exit with failure and output the mismatching versions:
 
 ```pt
-eslint has more than one version: ^7.0.0 (1 usage), ^7.1.0 (5 usages)
-sinon has more than one version: ^1.17.7 (1 usage), ^9.0.3 (3 usages)
+eslint has more than one version:
+	^7.8.9 (1 usage)
+	^8.0.0 (1 usage)
+sinon has more than one version:
+	1.2.0 (2 usages)
+	1.3.0 (1 usage)
 ```
 
 ## Options

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -14,7 +14,7 @@ export function mismatchingVersionsToOutputLines(
         .sort((a, b) => compareRanges(a.version, b.version))
         .map(
           (versionObj) =>
-            `${versionObj.version} (${versionObj.count} ${pluralizeUsage(
+            `${chalk.greenBright(versionObj.version)} (${versionObj.count} ${pluralizeUsage(
               versionObj.count
             )})`
         )

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -12,7 +12,7 @@ export function mismatchingVersionsToOutputLines(
         .sort((a, b) => compareRanges(a.version, b.version))
         .map(
           (versionObj) =>
-            `\t${chalk.greenBright(versionObj.version)} (${
+            `\t${chalk.redBright(versionObj.version)} (${
               versionObj.count
             } ${pluralizeUsage(versionObj.count)})`
         )

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-
 import type { MismatchingDependencyVersions } from './dependency-versions.js';
 import { compareRanges } from './dependency-versions.js';
 

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -14,6 +14,7 @@ export function mismatchingVersionsToOutputLines(
         .sort((a, b) => compareRanges(a.version, b.version))
         .map(
           (versionObj) =>
+            // eslint-disable-next-line prettier/prettier
             `${chalk.greenBright(versionObj.version)} (${versionObj.count} ${pluralizeUsage(
               versionObj.count
             )})`

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -8,18 +8,15 @@ export function mismatchingVersionsToOutputLines(
 ): string[] {
   return mismatchingDependencyVersions.map(
     (obj) =>
-      `${chalk.bold(
-        obj.dependency
-      )} has more than one version:\n  ${obj.versions
+      `${chalk.bold(obj.dependency)} has more than one version:\n${obj.versions
         .sort((a, b) => compareRanges(a.version, b.version))
         .map(
           (versionObj) =>
-            // eslint-disable-next-line prettier/prettier
-            `${chalk.greenBright(versionObj.version)} (${versionObj.count} ${pluralizeUsage(
+            `\t${chalk.greenBright(versionObj.version)} (${
               versionObj.count
-            )})`
+            } ${pluralizeUsage(versionObj.count)})`
         )
-        .join('\n  ')}`
+        .join('\n')}`
   );
 }
 

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+
 import type { MismatchingDependencyVersions } from './dependency-versions.js';
 import { compareRanges } from './dependency-versions.js';
 
@@ -6,7 +8,9 @@ export function mismatchingVersionsToOutputLines(
 ): string[] {
   return mismatchingDependencyVersions.map(
     (obj) =>
-      `${obj.dependency} has more than one version: ${obj.versions
+      `${chalk.bold(
+        obj.dependency
+      )} has more than one version:\n  ${obj.versions
         .sort((a, b) => compareRanges(a.version, b.version))
         .map(
           (versionObj) =>
@@ -14,7 +18,7 @@ export function mismatchingVersionsToOutputLines(
               versionObj.count
             )})`
         )
-        .join(', ')}`
+        .join('\n  ')}`
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-dependency-version-consistency",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "Ensures dependencies are on consistent versions across a monorepo.",
   "keywords": [
     "dependencies",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:types": "tsc",
     "prepublishOnly": "tsc",
     "release": "release-it",
-    "test": "node --loader ts-node/esm node_modules/mocha/lib/cli/cli --extension ts --recursive test"
+    "test": "node --loader ts-node/esm node_modules/mocha/lib/cli/cli --colors --extension ts --recursive test"
   },
   "nyc": {
     "branches": 100,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-dependency-version-consistency",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Ensures dependencies are on consistent versions across a monorepo.",
   "keywords": [
     "dependencies",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "statements": 100
   },
   "dependencies": {
+    "chalk": "^4.1.2",
     "commander": "^8.1.0",
     "edit-json-file": "^1.6.0",
     "semver": "^7.3.5",

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -31,9 +31,9 @@ describe('Utils | output', function () {
           },
         ]),
         [
-          '\u001B[1mfoo\u001B[22m has more than one version:\n  \u001B[92m1.2.3\u001B[39m (1 usage)\n  \u001B[92m4.5.6\u001B[39m (2 usages)',
-          '\u001B[1mbar\u001B[22m has more than one version:\n  \u001B[92m1.4.0\u001B[39m (3 usages)\n  \u001B[92m2.0.0\u001B[39m (4 usages)',
-          '\u001B[1mbaz\u001B[22m has more than one version:\n  \u001B[92m^1.0.0\u001B[39m (1 usage)\n  \u001B[92m~2.0.0\u001B[39m (1 usage)\n  \u001B[92m^2.0.0\u001B[39m (1 usage)',
+          '\u001B[1mfoo\u001B[22m has more than one version:\n\t\u001B[92m1.2.3\u001B[39m (1 usage)\n\t\u001B[92m4.5.6\u001B[39m (2 usages)',
+          '\u001B[1mbar\u001B[22m has more than one version:\n\t\u001B[92m1.4.0\u001B[39m (3 usages)\n\t\u001B[92m2.0.0\u001B[39m (4 usages)',
+          '\u001B[1mbaz\u001B[22m has more than one version:\n\t\u001B[92m^1.0.0\u001B[39m (1 usage)\n\t\u001B[92m~2.0.0\u001B[39m (1 usage)\n\t\u001B[92m^2.0.0\u001B[39m (1 usage)',
         ]
       );
     });

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -31,9 +31,9 @@ describe('Utils | output', function () {
           },
         ]),
         [
-          '\u001B[1mfoo\u001B[22m has more than one version:\n\t\u001B[92m1.2.3\u001B[39m (1 usage)\n\t\u001B[92m4.5.6\u001B[39m (2 usages)',
-          '\u001B[1mbar\u001B[22m has more than one version:\n\t\u001B[92m1.4.0\u001B[39m (3 usages)\n\t\u001B[92m2.0.0\u001B[39m (4 usages)',
-          '\u001B[1mbaz\u001B[22m has more than one version:\n\t\u001B[92m^1.0.0\u001B[39m (1 usage)\n\t\u001B[92m~2.0.0\u001B[39m (1 usage)\n\t\u001B[92m^2.0.0\u001B[39m (1 usage)',
+          '\u001B[1mfoo\u001B[22m has more than one version:\n\t\u001B[91m1.2.3\u001B[39m (1 usage)\n\t\u001B[91m4.5.6\u001B[39m (2 usages)',
+          '\u001B[1mbar\u001B[22m has more than one version:\n\t\u001B[91m1.4.0\u001B[39m (3 usages)\n\t\u001B[91m2.0.0\u001B[39m (4 usages)',
+          '\u001B[1mbaz\u001B[22m has more than one version:\n\t\u001B[91m^1.0.0\u001B[39m (1 usage)\n\t\u001B[91m~2.0.0\u001B[39m (1 usage)\n\t\u001B[91m^2.0.0\u001B[39m (1 usage)',
         ]
       );
     });

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -31,9 +31,9 @@ describe('Utils | output', function () {
           },
         ]),
         [
-          'foo has more than one version: 1.2.3 (1 usage), 4.5.6 (2 usages)',
-          'bar has more than one version: 1.4.0 (3 usages), 2.0.0 (4 usages)',
-          'baz has more than one version: ^1.0.0 (1 usage), ~2.0.0 (1 usage), ^2.0.0 (1 usage)',
+          '\u001B[1mfoo\u001B[22m has more than one version:\n  1.2.3 (1 usage)\n  4.5.6 (2 usages)',
+          '\u001B[1mbar\u001B[22m has more than one version:\n  1.4.0 (3 usages)\n  2.0.0 (4 usages)',
+          '\u001B[1mbaz\u001B[22m has more than one version:\n  ^1.0.0 (1 usage)\n  ~2.0.0 (1 usage)\n  ^2.0.0 (1 usage)',
         ]
       );
     });

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -31,9 +31,9 @@ describe('Utils | output', function () {
           },
         ]),
         [
-          '\u001B[1mfoo\u001B[22m has more than one version:\n  1.2.3 (1 usage)\n  4.5.6 (2 usages)',
-          '\u001B[1mbar\u001B[22m has more than one version:\n  1.4.0 (3 usages)\n  2.0.0 (4 usages)',
-          '\u001B[1mbaz\u001B[22m has more than one version:\n  ^1.0.0 (1 usage)\n  ~2.0.0 (1 usage)\n  ^2.0.0 (1 usage)',
+          '\u001B[1mfoo\u001B[22m has more than one version:\n  \u001B[92m1.2.3\u001B[39m (1 usage)\n  \u001B[92m4.5.6\u001B[39m (2 usages)',
+          '\u001B[1mbar\u001B[22m has more than one version:\n  \u001B[92m1.4.0\u001B[39m (3 usages)\n  \u001B[92m2.0.0\u001B[39m (4 usages)',
+          '\u001B[1mbaz\u001B[22m has more than one version:\n  \u001B[92m^1.0.0\u001B[39m (1 usage)\n  \u001B[92m~2.0.0\u001B[39m (1 usage)\n  \u001B[92m^2.0.0\u001B[39m (1 usage)',
         ]
       );
     });


### PR DESCRIPTION
Before:

<img width="466" alt="Screen Shot 2021-09-05 at 2 35 20 PM" src="https://user-images.githubusercontent.com/3535749/132139242-e9d5987c-8b5a-4a55-bfe9-4b3f1f06f51c.png">

After:

<img width="223" alt="Screen Shot 2021-09-05 at 2 55 24 PM" src="https://user-images.githubusercontent.com/3535749/132139858-7a3b54f8-c5fe-4d61-9c67-2fda130b0bb5.png">

