### PR TITLE
Remove non-existent option from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,12 @@
     "check-dependency-version-consistency": "dist/bin/check-dependency-version-consistency.js"
   },
   "scripts": {
-    "build": "tsc",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
+    "build": "tsc",
     "lint:docs": "markdownlint '**/*.md'",
-    "lint:js": "eslint --cache . --fix",
+    "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
-    "lint:package-json-sorting:fix": "sort-package-json --fix package.json",
     "lint:types": "tsc",
     "prepublishOnly": "tsc",
     "release": "release-it",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "check-dependency-version-consistency": "dist/bin/check-dependency-version-consistency.js"
   },
   "scripts": {
-    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "build": "tsc",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:docs": "markdownlint '**/*.md'",
     "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "tsc",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:docs": "markdownlint '**/*.md'",
-    "lint:js": "eslint --cache .",
+    "lint:js": "eslint --cache . --fix",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
     "lint:package-json-sorting:fix": "sort-package-json --fix package.json",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
+    "lint:package-json-sorting:fix": "sort-package-json package.json",
     "lint:types": "tsc",
     "prepublishOnly": "tsc",
     "release": "release-it",


### PR DESCRIPTION
`sort-package-json` does not have a `--fix` option.