### PR TITLE
Use table to display mismatching version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,21 @@ If there are no dependency mismatches, the program will exit with success.
 If there are any dependency mismatches, the program will exit with failure and output the mismatching versions:
 
 ```pt
-eslint has more than one version:
-    ^7.8.9 (1 usage)
-    ^8.0.0 (1 usage)
-sinon has more than one version:
-    1.2.0 (2 usages)
-    1.3.0 (1 usage)
+Found 2 dependencies with mismatching versions across the workspace.
+╔════════╤════════╗
+║ eslint │ Usages ║
+╟────────┼────────╢
+║ ^7.0.0 │ 5      ║
+╟────────┼────────╢
+║ ^8.0.0 │ 1      ║
+╚════════╧════════╝
+╔═════════╤════════╗
+║ globby  │ Usages ║
+╟─────────┼────────╢
+║ ^7.1.1  │ 1      ║
+╟─────────┼────────╢
+║ ^11.0.0 │ 2      ║
+╚═════════╧════════╝
 ```
 
 ## Options

--- a/bin/check-dependency-version-consistency.ts
+++ b/bin/check-dependency-version-consistency.ts
@@ -9,7 +9,7 @@ import {
   filterOutIgnoredDependencies,
   fixMismatchingVersions,
 } from '../lib/dependency-versions.js';
-import { mismatchingVersionsToOutputLines } from '../lib/output.js';
+import { mismatchingVersionsToOutput } from '../lib/output.js';
 import { join, dirname } from 'node:path';
 import type { PackageJson } from 'type-fest';
 import { fileURLToPath } from 'node:url';
@@ -63,9 +63,7 @@ function run() {
 
       // Show output.
       if (mismatchingVersions.length > 0) {
-        const outputLines =
-          mismatchingVersionsToOutputLines(mismatchingVersions);
-        outputLines.forEach((line) => console.log(line));
+        console.log(mismatchingVersionsToOutput(mismatchingVersions));
         process.exitCode = 1;
       }
     })

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,24 +1,32 @@
 import chalk from 'chalk';
 import type { MismatchingDependencyVersions } from './dependency-versions.js';
 import { compareRanges } from './dependency-versions.js';
+import { table } from 'table';
 
-export function mismatchingVersionsToOutputLines(
+export function mismatchingVersionsToOutput(
   mismatchingDependencyVersions: MismatchingDependencyVersions
-): string[] {
-  return mismatchingDependencyVersions.map(
-    (obj) =>
-      `${chalk.bold(obj.dependency)} has more than one version:\n${obj.versions
-        .sort((a, b) => compareRanges(a.version, b.version))
-        .map(
-          (versionObj) =>
-            `\t${chalk.redBright(versionObj.version)} (${
-              versionObj.count
-            } ${pluralizeUsage(versionObj.count)})`
-        )
-        .join('\n')}`
-  );
-}
+): string {
+  if (mismatchingDependencyVersions.length === 0) {
+    throw new Error('No mismatching versions to output.');
+  }
 
-function pluralizeUsage(count: number) {
-  return count === 1 ? 'usage' : 'usages';
+  const tables = mismatchingDependencyVersions
+    .map((obj) => {
+      const headers = [chalk.bold(obj.dependency), 'Usages'];
+      const rows = obj.versions
+        .sort((a, b) => compareRanges(a.version, b.version))
+        .map((versionObj) => [
+          chalk.redBright(versionObj.version),
+          versionObj.count,
+        ]);
+      return table([headers, ...rows]);
+    })
+    .join('');
+
+  return [
+    `Found ${mismatchingDependencyVersions.length} ${
+      mismatchingDependencyVersions.length === 1 ? 'dependency' : 'dependencies'
+    } with mismatching versions across the workspace.`,
+    tables,
+  ].join('\n');
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "commander": "^8.1.0",
     "edit-json-file": "^1.6.0",
     "semver": "^7.3.5",
+    "table": "^6.7.1",
     "type-fest": "^2.1.0"
   },
   "devDependencies": {

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -1,12 +1,12 @@
 import 'mocha'; // eslint-disable-line import/no-unassigned-import -- to get Mocha types to work
-import { mismatchingVersionsToOutputLines } from '../../lib/output.js';
-import { deepStrictEqual } from 'node:assert';
+import { mismatchingVersionsToOutput } from '../../lib/output.js';
+import { strictEqual, throws } from 'node:assert';
 
 describe('Utils | output', function () {
   describe('#mismatchingVersionsToOutputLines', function () {
     it('behaves correctly', function () {
-      deepStrictEqual(
-        mismatchingVersionsToOutputLines([
+      strictEqual(
+        mismatchingVersionsToOutput([
           {
             dependency: 'foo',
             versions: [
@@ -30,16 +30,39 @@ describe('Utils | output', function () {
             ],
           },
         ]),
-        [
-          '\u001B[1mfoo\u001B[22m has more than one version:\n\t\u001B[91m1.2.3\u001B[39m (1 usage)\n\t\u001B[91m4.5.6\u001B[39m (2 usages)',
-          '\u001B[1mbar\u001B[22m has more than one version:\n\t\u001B[91m1.4.0\u001B[39m (3 usages)\n\t\u001B[91m2.0.0\u001B[39m (4 usages)',
-          '\u001B[1mbaz\u001B[22m has more than one version:\n\t\u001B[91m^1.0.0\u001B[39m (1 usage)\n\t\u001B[91m~2.0.0\u001B[39m (1 usage)\n\t\u001B[91m^2.0.0\u001B[39m (1 usage)',
-        ]
+        `Found 3 dependencies with mismatching versions across the workspace.
+╔═══════╤════════╗
+║ \u001B[1mfoo\u001B[22m   │ Usages ║
+╟───────┼────────╢
+║ \u001B[91m1.2.3\u001B[39m │ 1      ║
+╟───────┼────────╢
+║ \u001B[91m4.5.6\u001B[39m │ 2      ║
+╚═══════╧════════╝
+╔═══════╤════════╗
+║ \u001B[1mbar\u001B[22m   │ Usages ║
+╟───────┼────────╢
+║ \u001B[91m1.4.0\u001B[39m │ 3      ║
+╟───────┼────────╢
+║ \u001B[91m2.0.0\u001B[39m │ 4      ║
+╚═══════╧════════╝
+╔════════╤════════╗
+║ \u001B[1mbaz\u001B[22m    │ Usages ║
+╟────────┼────────╢
+║ \u001B[91m^1.0.0\u001B[39m │ 1      ║
+╟────────┼────────╢
+║ \u001B[91m~2.0.0\u001B[39m │ 1      ║
+╟────────┼────────╢
+║ \u001B[91m^2.0.0\u001B[39m │ 1      ║
+╚════════╧════════╝
+`
       );
     });
 
     it('behaves correctly with empty input', function () {
-      deepStrictEqual(mismatchingVersionsToOutputLines([]), []);
+      throws(
+        () => mismatchingVersionsToOutput([]),
+        new Error('No mismatching versions to output.')
+      );
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,7 +5098,7 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-table@^6.0.9:
+table@^6.0.9, table@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
   integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==


### PR DESCRIPTION
Fixes #188.

* Moves data into table
* Adds summary line at top with number of dependencies that have inconsistent versions

## Screenshot

| Before | After |
| --- | --- |
| <img width="278" alt="Screen Shot 2021-09-08 at 9 45 00 AM" src="https://user-images.githubusercontent.com/698306/132550622-4b844fa1-f2e4-491f-903d-543bcb2fa881.png">| <img width="482" alt="Screen Shot 2021-09-07 at 5 41 05 PM" src="https://user-images.githubusercontent.com/698306/132450274-1f793bba-57d6-426a-ae78-a84264ad4099.png"> | 
