### PR TITLE
Improve discoverability of `fix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If there are no dependency mismatches, the program will exit with success.
 If there are any dependency mismatches, the program will exit with failure and output the mismatching versions:
 
 ```pt
-Found 2 dependencies with mismatching versions across the workspace.
+Found 2 dependencies with mismatching versions across the workspace. Fix with `--fix`.
 ╔════════╤════════╤═════════════════════════════╗
 ║ eslint │ Usages │ Packages                    ║
 ╟────────┼────────┼─────────────────────────────╢

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -35,7 +35,7 @@ export function mismatchingVersionsToOutput(
   return [
     `Found ${mismatchingDependencyVersions.length} ${
       mismatchingDependencyVersions.length === 1 ? 'dependency' : 'dependencies'
-    } with mismatching versions across the workspace.`,
+    } with mismatching versions across the workspace. Fix with \`--fix\`.`,
     tables,
   ].join('\n');
 }

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -51,7 +51,7 @@ describe('Utils | output', function () {
             ],
           },
         ]),
-        `Found 3 dependencies with mismatching versions across the workspace.
+        `Found 3 dependencies with mismatching versions across the workspace. Fix with \`--fix\`.
 ╔═══════╤════════╤══════════╗
 ║ \u001B[1mfoo\u001B[22m   │ Usages │ Packages ║
 ╟───────┼────────┼──────────╢


### PR DESCRIPTION
Improves discoverability of this autofix option by showing it when the user sees the mismatching version output. Many users may not realize they can automatically fix all problems detected.