### PR TITLE
Add dependency caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,14 @@ jobs:
       with:
         path: |
           node_modules
+          .cache/yarn
         key: check-dependency-version-consistency-${{ hashFiles('yarn.lock') }}
         restore-keys: check-dependency-version-consistency
 
     - name: Install dependencies
       run: yarn install --frozen-lockfile --non-interactive
+      env:
+        YARN_CACHE_FOLDER: .cache/yarn
 
     - name: Run linters
       run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+        key: check-dependency-version-consistency-${{ hashFiles('yarn.lock') }}
+        restore-keys: check-dependency-version-consistency
+
     - name: Install dependencies
       run: yarn install --frozen-lockfile --non-interactive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,3 @@ jobs:
 
     - name: Run tests
       run: yarn test
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Cache dependencies
-      id: cache-dependencies
       uses: actions/cache@v2
       with:
         path: |


### PR DESCRIPTION
This PR speeds up CI times on GitHub Actions.

Before:
<img width="309" alt="Screen Shot 2021-09-18 at 10 14 47 AM" src="https://user-images.githubusercontent.com/3535749/133893675-bb34eb35-71d8-47a2-9e34-1da49c478cd7.png">

After:
<img width="301" alt="Screen Shot 2021-09-18 at 10 15 07 AM" src="https://user-images.githubusercontent.com/3535749/133893680-9b24206f-dbc6-4d5b-904b-3d52659bbd65.png">

References:
* https://classic.yarnpkg.com/en/docs/cli/cache/#toc-change-the-cache-path-for-yarn
* https://github.com/actions/cache