### PR TITLE
Fix autofixer when dots are present in dependency name

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -201,7 +201,10 @@ export function fixMismatchingVersions(
             autosave: true,
           });
           packageJsonEditor.set(
-            `devDependencies.${mismatchingVersion.dependency}`,
+            `devDependencies.${mismatchingVersion.dependency.replace(
+              /\./g, // Escape dots.
+              '\\.'
+            )}`,
             fixedVersion
           );
         }
@@ -216,7 +219,10 @@ export function fixMismatchingVersions(
             autosave: true,
           });
           packageJsonEditor.set(
-            `dependencies.${mismatchingVersion.dependency}`,
+            `dependencies.${mismatchingVersion.dependency.replace(
+              /\./g, // Escape dots.
+              '\\.'
+            )}`,
             fixedVersion
           );
         }


### PR DESCRIPTION
* Escapes dots in dependency names when passing to `edit-json-file` to avoid screwing up package.json structure
* Add tests

Inspired by #229.

Fixes #228.