### PR TITLE
Skip GitHub Actions CI for documentation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:


### PR DESCRIPTION
PR to skip GitHub Actions CI when only markdown files are changed.

References:
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths