### PR TITLE
Avoid crash when abnormal version present

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -23,7 +23,13 @@ export function mismatchingVersionsToOutput(
       );
 
       const rows = obj.versions
-        .sort((a, b) => compareRanges(b.version, a.version))
+        .sort((a, b) => {
+          try {
+            return compareRanges(b.version, a.version);
+          } catch {
+            return 0;
+          }
+        })
         .map((versionObj) => {
           const usageCount = versionObj.packages.length;
           const packageNames = versionObj.packages.map((pkg) =>

--- a/test/lib/output.ts
+++ b/test/lib/output.ts
@@ -50,8 +50,21 @@ describe('Utils | output', function () {
               },
             ],
           },
+          {
+            dependency: 'biz',
+            versions: [
+              {
+                version: '^1.0.0',
+                packages: ['package1'],
+              },
+              {
+                version: 'workspace:*', // Invalid/abnormal version.
+                packages: ['package2'],
+              },
+            ],
+          },
         ]),
-        `Found 3 dependencies with mismatching versions across the workspace. Fix with \`--fix\`.
+        `Found 4 dependencies with mismatching versions across the workspace. Fix with \`--fix\`.
 ╔═══════╤════════╤══════════════════╗
 ║ \u001B[1mfoo\u001B[22m   │ Usages │ Packages         ║
 ╟───────┼────────┼──────────────────╢
@@ -75,6 +88,13 @@ describe('Utils | output', function () {
 ╟────────┼────────┼──────────╢
 ║ \u001B[91m^1.0.0\u001B[39m │ 1      │ package3 ║
 ╚════════╧════════╧══════════╝
+╔═════════════╤════════╤══════════╗
+║ \u001B[1mbiz\u001B[22m         │ Usages │ Packages ║
+╟─────────────┼────────┼──────────╢
+║ \u001B[91m^1.0.0\u001B[39m      │ 1      │ package1 ║
+╟─────────────┼────────┼──────────╢
+║ \u001B[91mworkspace:*\u001B[39m │ 1      │ package2 ║
+╚═════════════╧════════╧══════════╝
 `
       );
     });


### PR DESCRIPTION
Fixes #250.

```
"dependencies": {
    "foo-bar": "workspace:*",
}
```

Previous output:

```
Invalid Version: workspace:*
```