### PR TITLE
Add `--ignore-dep-pattern` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Found 2 dependencies with mismatching versions across the workspace. Fix with `-
 | --- | --- |
 | `--fix` | Whether to autofix inconsistencies (using highest version present). |
 | `--ignore-dep` | Dependency to ignore mismatches for (option can be repeated). |
+| `--ignore-dep-pattern` | RegExp of dependency names to ignore mismatches for (option can be repeated). |
 
 ## Related
 

--- a/bin/check-dependency-version-consistency.ts
+++ b/bin/check-dependency-version-consistency.ts
@@ -44,17 +44,31 @@ function run() {
       false
     )
     .option(
-      '--ignore-dep <dependency>',
+      '--ignore-dep <dependency-name>',
       'Dependency to ignore (option can be repeated)',
       collect,
       []
     )
-    .action(function (path, options: { ignoreDep: string[]; fix: boolean }) {
+    .option(
+      '--ignore-dep-pattern <dependency-name-pattern>',
+      'RegExp of dependency names to ignore (option can be repeated)',
+      collect,
+      []
+    )
+    .action(function (
+      path,
+      options: {
+        ignoreDep: string[];
+        ignoreDepPattern: RegExp[];
+        fix: boolean;
+      }
+    ) {
       // Calculate.
       const dependencyVersions = calculateVersionsForEachDependency(path);
       let mismatchingVersions = filterOutIgnoredDependencies(
         calculateMismatchingVersions(dependencyVersions),
-        options.ignoreDep
+        options.ignoreDep,
+        options.ignoreDepPattern
       );
 
       if (options.fix) {

--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -149,7 +149,8 @@ export function calculateMismatchingVersions(
 
 export function filterOutIgnoredDependencies(
   mismatchingVersions: MismatchingDependencyVersions,
-  ignoredDependencies: string[]
+  ignoredDependencies: string[],
+  ignoredDependencyPatterns: RegExp[]
 ): MismatchingDependencyVersions {
   for (const ignoreDependency of ignoredDependencies) {
     if (
@@ -165,7 +166,10 @@ export function filterOutIgnoredDependencies(
   }
   return mismatchingVersions.filter(
     (mismatchingVersion) =>
-      !ignoredDependencies.includes(mismatchingVersion.dependency)
+      !ignoredDependencies.includes(mismatchingVersion.dependency) &&
+      !ignoredDependencyPatterns.some((ignoreDependencyPattern) =>
+        mismatchingVersion.dependency.match(ignoreDependencyPattern)
+      )
   );
 }
 

--- a/test/lib/dependency-versions.ts
+++ b/test/lib/dependency-versions.ts
@@ -93,7 +93,35 @@ describe('Utils | dependency-versions', function () {
         calculateVersionsForEachDependency(FIXTURE_PATH_INCONSISTENT_VERSIONS)
       );
       deepStrictEqual(
-        filterOutIgnoredDependencies(dependencyVersions, ['foo']),
+        filterOutIgnoredDependencies(dependencyVersions, ['foo'], []),
+        [
+          {
+            dependency: 'baz',
+            versions: [
+              {
+                version: '^7.8.9',
+                packages: [join('scope1', 'package1')],
+              },
+              {
+                version: '^8.0.0',
+                packages: [join('scope1', 'package2')],
+              },
+            ],
+          },
+        ]
+      );
+    });
+
+    it('filters out an ignored dependency with regexp', function () {
+      const dependencyVersions = calculateMismatchingVersions(
+        calculateVersionsForEachDependency(FIXTURE_PATH_INCONSISTENT_VERSIONS)
+      );
+      deepStrictEqual(
+        filterOutIgnoredDependencies(
+          dependencyVersions,
+          [],
+          [new RegExp('^f.+$')]
+        ),
         [
           {
             dependency: 'baz',
@@ -118,10 +146,28 @@ describe('Utils | dependency-versions', function () {
       );
       throws(
         () =>
-          filterOutIgnoredDependencies(dependencyVersions, ['nonexistentDep']),
+          filterOutIgnoredDependencies(
+            dependencyVersions,
+            ['nonexistentDep'],
+            []
+          ),
         new Error(
           "Specified option '--ignore-dep nonexistentDep', but no mismatches detected."
         )
+      );
+    });
+
+    it('does not throw when unnecessarily regexp-ignoring a dependency that has no mismatches (less strict vs. --ignore-dep to provide greater flexibility)', function () {
+      const dependencyVersions = calculateMismatchingVersions(
+        calculateVersionsForEachDependency(FIXTURE_PATH_INCONSISTENT_VERSIONS)
+      );
+      strictEqual(
+        filterOutIgnoredDependencies(
+          dependencyVersions,
+          [],
+          [new RegExp('nonexistentDep')]
+        ).length,
+        2
       );
     });
   });


### PR DESCRIPTION
Provide a RegExp version of the existing `--ignore-dep` option.