### PR TITLE
Fix incorrect autofix for nested dependency

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -201,12 +201,15 @@ export function fixMismatchingVersions(
             autosave: true,
             stringify_eol: packageJsonEndsInNewline, // If a newline at end of file exists, keep it.
           });
+
           packageJsonEditor.set(
             `devDependencies.${mismatchingVersion.dependency.replace(
               /\./g, // Escape dots.
               '\\.'
             )}`,
-            fixedVersion
+            fixedVersion,
+          // @ts-ignore (@types/edit-json-file not available for 1.7)
+           { preservePaths: false }
           );
         }
 
@@ -225,7 +228,9 @@ export function fixMismatchingVersions(
               /\./g, // Escape dots.
               '\\.'
             )}`,
-            fixedVersion
+            fixedVersion,
+            // @ts-ignore (@types/edit-json-file not available for 1.7)
+            { preservePaths: false }
           );
         }
       }

--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -216,8 +216,9 @@ export function fixMismatchingVersions(
               '\\.'
             )}`,
             fixedVersion,
-          // @ts-ignore (@types/edit-json-file not available for 1.7)
-           { preservePaths: false }
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore (@types/edit-json-file not available for 1.7)
+            { preservePaths: false }
           );
         }
 
@@ -237,6 +238,7 @@ export function fixMismatchingVersions(
               '\\.'
             )}`,
             fixedVersion,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore (@types/edit-json-file not available for 1.7)
             { preservePaths: false }
           );

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^8.1.0",
-    "edit-json-file": "^1.6.0",
+    "edit-json-file": "^1.7.0",
     "globby": "^12.0.2",
     "semver": "^7.3.5",
     "table": "^6.7.1",
     "type-fest": "^2.1.0"
   },
   "devDependencies": {
-    "@types/edit-json-file": "^1.6.0",
+    "@types/edit-json-file": "1.6.1",
     "@types/mocha": "^9.0.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^17.0.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "type-fest": "^2.1.0"
   },
   "devDependencies": {
-    "@types/edit-json-file": "1.6.1",
+    "@types/edit-json-file": "^1.6.1",
     "@types/mocha": "^9.0.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^17.0.5",

--- a/test/lib/dependency-versions.ts
+++ b/test/lib/dependency-versions.ts
@@ -182,8 +182,11 @@ describe('Utils | dependency-versions', function () {
         }),
         'scope1/package1': {
           'package.json': JSON.stringify({
-            dependencies: { foo: '^1.0.0', bar: '^3.0.0', 'a.b.c': '5.0.0'},
-            devDependencies: { 'one.two.three': '^4.1.0', '@types/one': '1.0.1' },
+            dependencies: { foo: '^1.0.0', bar: '^3.0.0', 'a.b.c': '5.0.0' },
+            devDependencies: {
+              'one.two.three': '^4.1.0',
+              '@types/one': '1.0.1',
+            },
           }),
         },
         'scope1/package2': {
@@ -193,7 +196,10 @@ describe('Utils | dependency-versions', function () {
               bar: 'invalidVersion',
               'a.b.c': '~5.5.0',
             },
-            devDependencies: { 'one.two.three': '^4.0.0', '@types/one': '1.0.0' },
+            devDependencies: {
+              'one.two.three': '^4.0.0',
+              '@types/one': '1.0.0',
+            },
           })}\n`, // Ends in newline.
         },
       });
@@ -283,16 +289,16 @@ describe('Utils | dependency-versions', function () {
 
       // @types/one
       strictEqual(
-      packageJson1.devDependencies &&
-      packageJson1.devDependencies['@types/one'],
-      '1.0.1',
-      'does not change package1 `@types/one` version since already at highest version'
+        packageJson1.devDependencies &&
+          packageJson1.devDependencies['@types/one'],
+        '1.0.1',
+        'does not change package1 `@types/one` version since already at highest version'
       );
       strictEqual(
-      packageJson2.devDependencies &&
-      packageJson2.devDependencies['@types/one'],
-      '1.0.1',
-      'updates the package2 `@types/one` version to the highest version'
+        packageJson2.devDependencies &&
+          packageJson2.devDependencies['@types/one'],
+        '1.0.1',
+        'updates the package2 `@types/one` version to the highest version'
       );
 
       // Check return value.

--- a/test/lib/dependency-versions.ts
+++ b/test/lib/dependency-versions.ts
@@ -136,8 +136,8 @@ describe('Utils | dependency-versions', function () {
         }),
         'scope1/package1': {
           'package.json': JSON.stringify({
-            dependencies: { foo: '^1.0.0', bar: '^3.0.0', 'a.b.c': '5.0.0' },
-            devDependencies: { 'one.two.three': '^4.1.0' },
+            dependencies: { foo: '^1.0.0', bar: '^3.0.0', 'a.b.c': '5.0.0'},
+            devDependencies: { 'one.two.three': '^4.1.0', '@types/one': '1.0.1' },
           }),
         },
         'scope1/package2': {
@@ -147,7 +147,7 @@ describe('Utils | dependency-versions', function () {
               bar: 'invalidVersion',
               'a.b.c': '~5.5.0',
             },
-            devDependencies: { 'one.two.three': '^4.0.0' },
+            devDependencies: { 'one.two.three': '^4.0.0', '@types/one': '1.0.0' },
           })}\n`, // Ends in newline.
         },
       });
@@ -233,6 +233,20 @@ describe('Utils | dependency-versions', function () {
           packageJson2.devDependencies['one.two.three'],
         '^4.1.0',
         'updates the package2 `one.two.three` version to the highest version'
+      );
+
+      // @types/one
+      strictEqual(
+      packageJson1.devDependencies &&
+      packageJson1.devDependencies['@types/one'],
+      '1.0.1',
+      'does not change package1 `@types/one` version since already at highest version'
+      );
+      strictEqual(
+      packageJson2.devDependencies &&
+      packageJson2.devDependencies['@types/one'],
+      '1.0.1',
+      'updates the package2 `@types/one` version to the highest version'
       );
 
       // Check return value.

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/edit-json-file@1.6.1":
+"@types/edit-json-file@^1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@types/edit-json-file/-/edit-json-file-1.6.1.tgz#ee4504545099b0ff968988a4cb34b5c797da6149"
   integrity sha512-3zWmE5D8sr1EKW4q4MH58o1Jn/1yOj/EpsU+6ZSw6KerqzQvc1UxERW2xkDTvvf5jDc7ABx+9JTCaW40X5lCIQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/edit-json-file@^1.6.0":
+"@types/edit-json-file@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@types/edit-json-file/-/edit-json-file-1.6.1.tgz#ee4504545099b0ff968988a4cb34b5c797da6149"
   integrity sha512-3zWmE5D8sr1EKW4q4MH58o1Jn/1yOj/EpsU+6ZSw6KerqzQvc1UxERW2xkDTvvf5jDc7ABx+9JTCaW40X5lCIQ==
@@ -1508,10 +1508,10 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-edit-json-file@^1.6.0:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/edit-json-file/-/edit-json-file-1.6.2.tgz#22a724fa82cffc6a28ed2d88947aa17657795168"
-  integrity sha512-RrN30juETHpFOHZ99nzSf6+P3SkxRq79qx0CKFCv+zMZYN0FzHdGYKJT3GEqNJ6/yFPBIZ04wzpJSrWrxiNGdA==
+edit-json-file@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/edit-json-file/-/edit-json-file-1.7.0.tgz#b0bfb626169890568c2668369a8e5202f5c49150"
+  integrity sha512-eIkLJ9i4ija7b2TbaLHy3scyjWFLzwM2Wa6kHbV4ppVLcCqn7FzqnO1vmCG3dLrkd+teWE3mvACfv166mO0VZg==
   dependencies:
     find-value "^1.0.12"
     iterate-object "^1.3.4"


### PR DESCRIPTION
I discovered a bug when fixing dependencies with a slash in the name (e.g. @types/jest) - rather than updating them in place, it was adding properties in the format ```"devDependencies.@types/jest": "^27.0.2",```

This PR fixes the issue. I had to upgrade the edit-json-file dependency to enable supplying options to `set`. Unfortunately typescript complains because @types/edit-json-file has not been updated to cover the new 3rd argument to `set`

I also updated a test to cover the bug which is being fixed.