### PR TITLE
Throw when unnecessarily using `--ignore-dep-pattern`

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -145,7 +145,18 @@ export function filterOutIgnoredDependencies(
       )
     ) {
       throw new Error(
-        `Specified option '--ignore-dep ${ignoreDependency}', but no mismatches detected.`
+        `Specified option '--ignore-dep ${ignoreDependency}', but no version mismatches detected for this dependency.`
+      );
+    }
+  }
+  for (const ignoredDependencyPattern of ignoredDependencyPatterns) {
+    if (
+      !mismatchingVersions.some((mismatchingVersion) =>
+        ignoredDependencyPattern.test(mismatchingVersion.dependency)
+      )
+    ) {
+      throw new Error(
+        `Specified option '--ignore-dep-pattern ${ignoredDependencyPattern}', but no matching dependencies with version mismatches detected.`
       );
     }
   }

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -226,23 +226,24 @@ describe('Utils | dependency-versions', function () {
       expect(() =>
         filterOutIgnoredDependencies(dependencyVersions, ['nonexistentDep'], [])
       ).toThrowErrorMatchingInlineSnapshot(
-        '"Specified option \'--ignore-dep nonexistentDep\', but no mismatches detected."'
+        '"Specified option \'--ignore-dep nonexistentDep\', but no version mismatches detected for this dependency."'
       );
     });
 
-    it('does not throw when unnecessarily regexp-ignoring a dependency that has no mismatches (less strict vs. --ignore-dep to provide greater flexibility)', function () {
+    it('throws when unnecessarily regexp-ignoring a dependency that has no mismatches', function () {
       const dependencyVersions = calculateMismatchingVersions(
         calculateVersionsForEachDependency(
           getPackagesHelper(FIXTURE_PATH_INCONSISTENT_VERSIONS)
         )
       );
-      strictEqual(
+      expect(() =>
         filterOutIgnoredDependencies(
           dependencyVersions,
           [],
           [new RegExp('nonexistentDep')]
-        ).length,
-        2
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        '"Specified option \'--ignore-dep-pattern /nonexistentDep/\', but no matching dependencies with version mismatches detected."'
       );
     });
   });


### PR DESCRIPTION
Changed my mind about this. Let's be more strict.

Follow-up to #298 which hasn't been released yet.