### PR TITLE
Tweak and add test for `filterOutIgnoredDependencies`

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -149,6 +149,7 @@ export function filterOutIgnoredDependencies(
       );
     }
   }
+
   for (const ignoredDependencyPattern of ignoredDependencyPatterns) {
     if (
       !mismatchingVersions.some((mismatchingVersion) =>
@@ -160,13 +161,18 @@ export function filterOutIgnoredDependencies(
       );
     }
   }
-  return mismatchingVersions.filter(
-    (mismatchingVersion) =>
-      !ignoredDependencies.includes(mismatchingVersion.dependency) &&
-      !ignoredDependencyPatterns.some((ignoreDependencyPattern) =>
-        mismatchingVersion.dependency.match(ignoreDependencyPattern)
-      )
-  );
+
+  if (ignoredDependencies.length > 0 || ignoredDependencyPatterns.length > 0) {
+    return mismatchingVersions.filter(
+      (mismatchingVersion) =>
+        !ignoredDependencies.includes(mismatchingVersion.dependency) &&
+        !ignoredDependencyPatterns.some((ignoreDependencyPattern) =>
+          mismatchingVersion.dependency.match(ignoreDependencyPattern)
+        )
+    );
+  }
+
+  return mismatchingVersions;
 }
 
 export function fixMismatchingVersions(

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -246,6 +246,17 @@ describe('Utils | dependency-versions', function () {
         '"Specified option \'--ignore-dep-pattern /nonexistentDep/\', but no matching dependencies with version mismatches detected."'
       );
     });
+
+    it('does not filter anything out when nothing to ignore', function () {
+      const dependencyVersions = calculateMismatchingVersions(
+        calculateVersionsForEachDependency(
+          getPackagesHelper(FIXTURE_PATH_INCONSISTENT_VERSIONS)
+        )
+      );
+      expect(
+        filterOutIgnoredDependencies(dependencyVersions, [], []).length
+      ).toStrictEqual(2);
+    });
   });
 
   describe('#fixMismatchingVersions', function () {


### PR DESCRIPTION
No behavior change.

Avoid unnecessary filtering of array when nothing to ignore. Add test.