### PR TITLE
Display which dependencies were fixed when running with `--fix`

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -61,3 +61,18 @@ export function mismatchingVersionsToOutput(
     tables,
   ].join('\n');
 }
+
+export function mismatchingVersionsFixedToOutput(
+  mismatchingDependencyVersions: MismatchingDependencyVersions
+): string {
+  if (mismatchingDependencyVersions.length === 0) {
+    throw new Error('No fixes to output.');
+  }
+
+  const dependencies = mismatchingDependencyVersions
+    .map((mismatchingVersion) => mismatchingVersion.dependency)
+    .sort();
+  return `Fixed versions for ${dependencies.length} ${
+    dependencies.length === 1 ? 'dependency' : 'dependencies'
+  }: ${dependencies.join(', ')}`;
+}

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -310,7 +310,7 @@ describe('Utils | dependency-versions', function () {
       const mismatchingVersions = calculateMismatchingVersions(
         calculateVersionsForEachDependency(packages)
       );
-      const fixedMismatchingVersions = fixMismatchingVersions(
+      const { fixed, notFixed } = fixMismatchingVersions(
         packages,
         mismatchingVersions
       );
@@ -388,8 +388,8 @@ describe('Utils | dependency-versions', function () {
       ).toStrictEqual('1.0.1');
 
       // Check return value.
-      // Should return only the dependency that could not be fixed due to the abnormal version present.
-      expect(fixedMismatchingVersions).toStrictEqual([
+      // Only one dependency should not be fixed due to the abnormal version present.
+      expect(notFixed).toStrictEqual([
         {
           dependency: 'bar',
           versions: [
@@ -406,6 +406,95 @@ describe('Utils | dependency-versions', function () {
               packages: [
                 expect.objectContaining({
                   path: join('@scope1', 'package2'),
+                }),
+              ],
+            },
+          ],
+        },
+      ]);
+      expect(fixed).toStrictEqual([
+        {
+          dependency: '@types/one',
+          versions: [
+            {
+              version: '1.0.0',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package2'),
+                }),
+              ],
+            },
+            {
+              version: '1.0.1',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package1'),
+                }),
+              ],
+            },
+          ],
+        },
+        {
+          dependency: 'a.b.c',
+          versions: [
+            {
+              version: '5.0.0',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package1'),
+                }),
+              ],
+            },
+            {
+              version: '~5.5.0',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package2'),
+                }),
+              ],
+            },
+          ],
+        },
+        {
+          dependency: 'foo',
+          versions: [
+            {
+              version: '^1.0.0',
+              packages: [
+                expect.objectContaining({
+                  path: '.',
+                }),
+                expect.objectContaining({
+                  path: join('@scope1', 'package1'),
+                }),
+              ],
+            },
+            {
+              version: '^2.0.0',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package2'),
+                }),
+              ],
+            },
+          ],
+        },
+        {
+          dependency: 'one.two.three',
+          versions: [
+            {
+              version: '^4.0.0',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package2'),
+                }),
+              ],
+            },
+            {
+              version: '^4.1.0',
+              packages: [
+                expect.objectContaining({
+                  path: join('@scope1', 'package1'),
                 }),
               ],
             },

--- a/test/lib/output-test.ts
+++ b/test/lib/output-test.ts
@@ -2,7 +2,10 @@ import {
   calculateVersionsForEachDependency,
   calculateMismatchingVersions,
 } from '../../lib/dependency-versions.js';
-import { mismatchingVersionsToOutput } from '../../lib/output.js';
+import {
+  mismatchingVersionsToOutput,
+  mismatchingVersionsFixedToOutput,
+} from '../../lib/output.js';
 import { getPackages } from '../../lib/workspace.js';
 import {
   FIXTURE_PATH_TESTING_OUTPUT,
@@ -90,6 +93,40 @@ describe('Utils | output', function () {
       ).toThrowErrorMatchingInlineSnapshot(
         '"No mismatching versions to output."'
       );
+    });
+  });
+
+  describe('#mismatchingVersionsFixedToOutputLines', function () {
+    it('behaves correctly', function () {
+      expect(
+        mismatchingVersionsFixedToOutput(
+          calculateMismatchingVersions(
+            calculateVersionsForEachDependency(
+              getPackages(FIXTURE_PATH_TESTING_OUTPUT, [], [], [], [])
+            )
+          )
+        )
+      ).toMatchInlineSnapshot(
+        '"Fixed versions for 4 dependencies: bar, baz, biz, foo"'
+      );
+    });
+
+    it('behaves correctly with a single fix', function () {
+      expect(
+        mismatchingVersionsFixedToOutput(
+          calculateMismatchingVersions(
+            calculateVersionsForEachDependency(
+              getPackages(FIXTURE_PATH_TESTING_OUTPUT, [], [], [], [])
+            )
+          ).slice(0, 1)
+        )
+      ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: bar"');
+    });
+
+    it('behaves correctly with empty input', function () {
+      expect(() =>
+        mismatchingVersionsFixedToOutput([])
+      ).toThrowErrorMatchingInlineSnapshot('"No fixes to output."');
     });
   });
 });


### PR DESCRIPTION
Fixes #200.

Example output:

```
yarn check-dependency-version-consistency --fix .
Fixed versions for 3 dependencies: eslint, qunit, typescript
```