### PR TITLE
Show new version in autofix output

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -212,16 +212,14 @@ export function fixMismatchingVersions(
     const versions = mismatchingVersion.versions.map(
       (object) => object.version
     );
-    let sortedVersions;
+    let fixedVersion;
     try {
-      sortedVersions = versions.sort(compareRanges);
+      fixedVersion = getHighestVersion(versions);
     } catch {
-      // Unable to sort so skip this dependency.
+      // Skip this dependency.
       notFixed.push(mismatchingVersion);
       continue;
     }
-
-    const fixedVersion = sortedVersions[sortedVersions.length - 1]; // Highest version will be sorted to end of list.
 
     let isFixed = false;
     for (const package_ of packages) {
@@ -298,4 +296,9 @@ export function compareRanges(a: string, b: string): 0 | -1 | 1 {
 
   // Greater version considered higher.
   return semver.gt(aVersion, bVersion) ? 1 : -1;
+}
+
+export function getHighestVersion(versions: string[]): string {
+  const sortedVersions = versions.sort(compareRanges);
+  return sortedVersions[sortedVersions.length - 1]; // Highest version will be sorted to end of list.
 }

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import type { MismatchingDependencyVersions } from './dependency-versions.js';
-import { compareRanges } from './dependency-versions.js';
+import { compareRanges, getHighestVersion } from './dependency-versions.js';
 import { table } from 'table';
 
 export function mismatchingVersionsToOutput(
@@ -69,10 +69,26 @@ export function mismatchingVersionsFixedToOutput(
     throw new Error('No fixes to output.');
   }
 
-  const dependencies = mismatchingDependencyVersions
-    .map((mismatchingVersion) => mismatchingVersion.dependency)
-    .sort();
-  return `Fixed versions for ${dependencies.length} ${
-    dependencies.length === 1 ? 'dependency' : 'dependencies'
-  }: ${dependencies.join(', ')}`;
+  const dependenciesAndFixedVersions = mismatchingDependencyVersions
+    .flatMap((mismatchingVersion) => {
+      let version;
+      try {
+        version = getHighestVersion(
+          mismatchingVersion.versions.map((v) => v.version)
+        );
+      } catch {
+        return []; // Ignore this dependency since unable to get the version that we would have fixed it to.
+      }
+      return {
+        dependency: mismatchingVersion.dependency,
+        version,
+      };
+    })
+    .sort((a, b) => a.dependency.localeCompare(b.dependency));
+
+  return `Fixed versions for ${dependenciesAndFixedVersions.length} ${
+    dependenciesAndFixedVersions.length === 1 ? 'dependency' : 'dependencies'
+  }: ${dependenciesAndFixedVersions
+    .map((object) => `${object.dependency} to ${object.version}`)
+    .join(', ')}`;
 }

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -89,6 +89,6 @@ export function mismatchingVersionsFixedToOutput(
   return `Fixed versions for ${dependenciesAndFixedVersions.length} ${
     dependenciesAndFixedVersions.length === 1 ? 'dependency' : 'dependencies'
   }: ${dependenciesAndFixedVersions
-    .map((object) => `${object.dependency} to ${object.version}`)
+    .map((object) => `${object.dependency}@${object.version}`)
     .join(', ')}`;
 }

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -4,6 +4,7 @@ import {
   filterOutIgnoredDependencies,
   fixMismatchingVersions,
   compareRanges,
+  getHighestVersion,
 } from '../../lib/dependency-versions.js';
 import { getPackages } from '../../lib/workspace.js';
 import {
@@ -543,6 +544,20 @@ describe('Utils | dependency-versions', function () {
       ).toThrowErrorMatchingInlineSnapshot('"Invalid Version: foo"');
       expect(() =>
         compareRanges('~6.0.0', 'foo')
+      ).toThrowErrorMatchingInlineSnapshot('"Invalid Version: foo"');
+    });
+  });
+
+  describe('#getHighestVersion', function () {
+    it('correctly chooses the higher range', function () {
+      // Just basic sanity checks to ensure the data is passed through to `compareRanges` which has extensive tests.
+      expect(getHighestVersion(['1.2.3', '1.2.2'])).toStrictEqual('1.2.3');
+      expect(getHighestVersion(['1.2.2', '1.2.3'])).toStrictEqual('1.2.3');
+    });
+
+    it('throws with invalid version', function () {
+      expect(() =>
+        getHighestVersion(['1.2.3', 'foo'])
       ).toThrowErrorMatchingInlineSnapshot('"Invalid Version: foo"');
     });
   });

--- a/test/lib/output-test.ts
+++ b/test/lib/output-test.ts
@@ -107,7 +107,7 @@ describe('Utils | output', function () {
           )
         )
       ).toMatchInlineSnapshot(
-        '"Fixed versions for 4 dependencies: bar, baz, biz, foo"'
+        '"Fixed versions for 3 dependencies: bar to 2.0.0, baz to ^2.0.0, foo to 4.5.6"'
       );
     });
 
@@ -120,7 +120,9 @@ describe('Utils | output', function () {
             )
           ).slice(0, 1)
         )
-      ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: bar"');
+      ).toMatchInlineSnapshot(
+        '"Fixed versions for 1 dependency: bar to 2.0.0"'
+      );
     });
 
     it('behaves correctly with empty input', function () {

--- a/test/lib/output-test.ts
+++ b/test/lib/output-test.ts
@@ -107,7 +107,7 @@ describe('Utils | output', function () {
           )
         )
       ).toMatchInlineSnapshot(
-        '"Fixed versions for 3 dependencies: bar to 2.0.0, baz to ^2.0.0, foo to 4.5.6"'
+        '"Fixed versions for 3 dependencies: bar@2.0.0, baz@^2.0.0, foo@4.5.6"'
       );
     });
 
@@ -120,9 +120,7 @@ describe('Utils | output', function () {
             )
           ).slice(0, 1)
         )
-      ).toMatchInlineSnapshot(
-        '"Fixed versions for 1 dependency: bar to 2.0.0"'
-      );
+      ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: bar@2.0.0"');
     });
 
     it('behaves correctly with empty input', function () {


### PR DESCRIPTION
Fixes #200.

Example output:

```
yarn check-dependency-version-consistency --fix .
Fixed versions for 3 dependencies: eslint@^7.0.0, qunit@^2.17.2, typescript@^4.5.2
```

Follow-up to: https://github.com/bmish/check-dependency-version-consistency/pull/320