### PR TITLE
Tell dependabot to increase versions in package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
-    versioning-strategy: 'increase'
+    versioning-strategy: 'increase' # Update versions in both package.json and lockfile
     schedule:
       interval: 'monthly'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    versioning-strategy: 'increase'
     schedule:
       interval: 'monthly'
 


### PR DESCRIPTION
For our `dependencies` in package.json, we need to update their versions in both package.json and the lockfile, not just the lockfile, for the update to have an effect on consumers. If we only update a version in the lockfile, it will affect us, but not consumers of this plugin.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy