### PR TITLE
Maintain range type when fixing to local package version

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -287,6 +287,14 @@ export function fixMismatchingVersions(
       continue;
     }
 
+    if (localPackage && localPackage.packageJson.version === fixedVersion) {
+      // When fixing to the version of a local package, don't just use the bare package version, but include the highest range type we have seen.
+      const highestRangeTypeSeen = getHighestRangeType(
+        versions.map((versionRange) => versionRangeToRange(versionRange))
+      );
+      fixedVersion = `${highestRangeTypeSeen}${semver.coerce(fixedVersion)}`;
+    }
+
     // Update the dependency version in each package.json.
     let isFixed = false;
     for (const package_ of packages) {
@@ -389,4 +397,10 @@ export function versionRangeToRange(versionRange: string): string {
 export function getLatestVersion(versions: string[]): string {
   const sortedVersions = versions.sort(compareVersionRanges);
   return sortedVersions[sortedVersions.length - 1]; // Latest version will be sorted to end of list.
+}
+
+// Example input: ['~', '^'], output: '^'
+export function getHighestRangeType(ranges: string[]): string {
+  const sorted = ranges.sort(compareRanges);
+  return sorted[sorted.length - 1]; // Range with highest precedence will be sorted to end of list.
 }

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -8,6 +8,7 @@ import {
   compareRanges,
   versionRangeToRange,
   getLatestVersion,
+  getHighestRangeType,
 } from '../../lib/dependency-versions.js';
 import { getPackages } from '../../lib/workspace.js';
 import {
@@ -632,7 +633,7 @@ describe('Utils | dependency-versions', function () {
 
         expect(
           packageJson1.dependencies && packageJson1.dependencies['package2']
-        ).toStrictEqual('2.0.0');
+        ).toStrictEqual('^2.0.0');
 
         expect(
           packageJson2.dependencies && packageJson2.dependencies['package1']
@@ -783,6 +784,16 @@ describe('Utils | dependency-versions', function () {
       expect(() =>
         getLatestVersion(['1.2.3', 'foo'])
       ).toThrowErrorMatchingInlineSnapshot('"Invalid Version: foo"');
+    });
+  });
+
+  describe('#getHighestRangeType', function () {
+    it('behaves correctly', function () {
+      expect(getHighestRangeType(['', ''])).toStrictEqual('');
+      expect(getHighestRangeType(['^', ''])).toStrictEqual('^');
+      expect(getHighestRangeType(['~', ''])).toStrictEqual('~');
+      expect(getHighestRangeType(['~', '^'])).toStrictEqual('^');
+      expect(getHighestRangeType(['^', '~'])).toStrictEqual('^');
     });
   });
 });


### PR DESCRIPTION
Fixes #349.

When a dependency is defined in a local package, use the highest range type we have seen for it during autofix.

Example:

```json
{
  "name": "package1",
  "dependencies": {
    "package2": "^0.0.0"
  }
}
```

`packages/package2/package.json`:

```json
{
  "name": "package2",
  "version": "1.0.0"
}
```

Previous autofix (loses `^`):

```
"package2": "1.0.0"
```

New autofix (maintains `^` range)::

```
"package2": "^1.0.0"
```