### PR TITLE
Autofix to increased latest version range

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -4,7 +4,7 @@ import {
   compareVersionRanges,
   compareVersionRangesSafe,
   versionRangeToRange,
-  getLatestVersion,
+  getIncreasedLatestVersion,
   getHighestRangeType,
 } from './semver.js';
 import semver from 'semver';
@@ -273,7 +273,7 @@ export function fixMismatchingVersions(
     );
     let fixedVersion;
     try {
-      fixedVersion = getLatestVersion(versions);
+      fixedVersion = getIncreasedLatestVersion(versions);
     } catch {
       // Skip this dependency.
       notFixed.push(mismatchingVersion);

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,6 +1,9 @@
 import chalk from 'chalk';
 import type { MismatchingDependencyVersions } from './dependency-versions.js';
-import { compareVersionRangesSafe, getLatestVersion } from './semver.js';
+import {
+  compareVersionRangesSafe,
+  getIncreasedLatestVersion,
+} from './semver.js';
 import { table } from 'table';
 
 export function mismatchingVersionsToOutput(
@@ -67,7 +70,7 @@ export function mismatchingVersionsFixedToOutput(
     .flatMap((mismatchingVersion) => {
       let version;
       try {
-        version = getLatestVersion(
+        version = getIncreasedLatestVersion(
           mismatchingVersion.versions.map((v) => v.version)
         );
       } catch {

--- a/lib/semver.ts
+++ b/lib/semver.ts
@@ -62,3 +62,32 @@ export function getHighestRangeType(ranges: string[]): string {
   const sorted = ranges.sort(compareRanges);
   return sorted[sorted.length - 1]; // Range with highest precedence will be sorted to end of list.
 }
+
+// Example input: ['1.5.0', '^1.0.0'], output: '^1.5.0'
+export function getIncreasedLatestVersion(versions: string[]): string {
+  const latestVersion = getLatestVersion(versions);
+  const latestVersionBare = semver.coerce(latestVersion);
+
+  let result = latestVersion;
+  let resultBare = latestVersionBare;
+  for (const version of versions) {
+    if (version === latestVersion) {
+      continue;
+    }
+
+    const versionBare = semver.coerce(version);
+
+    if (
+      latestVersionBare &&
+      semver.satisfies(latestVersionBare, version) &&
+      versionBare &&
+      semver.gt(latestVersionBare, versionBare) &&
+      resultBare
+    ) {
+      result = version.replace(String(versionBare), String(resultBare));
+      resultBare = semver.coerce(result);
+    }
+  }
+
+  return result;
+}

--- a/test/fixtures/increasable-range/package.json
+++ b/test/fixtures/increasable-range/package.json
@@ -1,0 +1,8 @@
+{
+    "workspaces": [
+        "*"
+    ],
+    "devDependencies": {
+        "foo": "^1.0.0"
+    }
+}

--- a/test/fixtures/increasable-range/package1/package.json
+++ b/test/fixtures/increasable-range/package1/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "package1",
+    "dependencies": {
+        "foo": "1.5.0"
+    }
+}

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -44,3 +44,7 @@ export const FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION = join(
   FIXTURE_PATH,
   'inconsistent-local-package-version'
 );
+export const FIXTURE_PATH_INCREASABLE_RANGE = join(
+  FIXTURE_PATH,
+  'increasable-range'
+);

--- a/test/lib/output-test.ts
+++ b/test/lib/output-test.ts
@@ -10,6 +10,7 @@ import { getPackages } from '../../lib/workspace.js';
 import {
   FIXTURE_PATH_TESTING_OUTPUT,
   FIXTURE_PATH_NAMES_NOT_MATCHING_LOCATIONS,
+  FIXTURE_PATH_INCREASABLE_RANGE,
 } from '../fixtures/index.js';
 
 describe('Utils | output', function () {
@@ -121,6 +122,18 @@ describe('Utils | output', function () {
           ).slice(0, 1)
         )
       ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: bar@2.0.0"');
+    });
+
+    it('behaves correctly with an increasable range', function () {
+      expect(
+        mismatchingVersionsFixedToOutput(
+          calculateMismatchingVersions(
+            calculateVersionsForEachDependency(
+              getPackages(FIXTURE_PATH_INCREASABLE_RANGE, [], [], [], [])
+            )
+          ).slice(0, 1)
+        )
+      ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: foo@^1.5.0"');
     });
 
     it('behaves correctly with empty input', function () {

--- a/test/lib/semver-test.ts
+++ b/test/lib/semver-test.ts
@@ -5,6 +5,7 @@ import {
   versionRangeToRange,
   getLatestVersion,
   getHighestRangeType,
+  getIncreasedLatestVersion,
 } from '../../lib/semver.js';
 
 describe('Utils | semver', function () {
@@ -110,6 +111,60 @@ describe('Utils | semver', function () {
       expect(getHighestRangeType(['~', ''])).toStrictEqual('~');
       expect(getHighestRangeType(['~', '^'])).toStrictEqual('^');
       expect(getHighestRangeType(['^', '~'])).toStrictEqual('^');
+    });
+  });
+
+  describe('#getIncreasedLatestVersion', function () {
+    it('behaves correctly', function () {
+      // ^
+      expect(getIncreasedLatestVersion(['^1.0.0', '1.5.0'])).toStrictEqual(
+        '^1.5.0'
+      );
+      expect(getIncreasedLatestVersion(['1.5.0', '^1.0.0'])).toStrictEqual(
+        '^1.5.0'
+      );
+      expect(getIncreasedLatestVersion(['^0.4.0', '^0.4.5'])).toStrictEqual(
+        '^0.4.5'
+      );
+      expect(getIncreasedLatestVersion(['^0.4.0', '0.5.0'])).toStrictEqual(
+        '0.5.0'
+      );
+      expect(getIncreasedLatestVersion(['^1.0.0', '2.0.0'])).toStrictEqual(
+        '2.0.0'
+      );
+      expect(getIncreasedLatestVersion(['^1.0.0', '^1.0.0'])).toStrictEqual(
+        '^1.0.0'
+      );
+
+      // ^ ~
+      expect(getIncreasedLatestVersion(['~1.5.0', '^1.0.0'])).toStrictEqual(
+        '^1.5.0'
+      );
+      expect(getIncreasedLatestVersion(['~1.5.0', '^2.0.0'])).toStrictEqual(
+        '^2.0.0'
+      );
+      expect(getIncreasedLatestVersion(['~2.0.0', '^1.5.0'])).toStrictEqual(
+        '~2.0.0'
+      );
+
+      // ~
+      expect(getIncreasedLatestVersion(['~1.4.0', '1.4.5'])).toStrictEqual(
+        '~1.4.5'
+      );
+      expect(getIncreasedLatestVersion(['~1.4.0', '~1.5.0'])).toStrictEqual(
+        '~1.5.0'
+      );
+      expect(getIncreasedLatestVersion(['~1.0.0', '~1.0.0'])).toStrictEqual(
+        '~1.0.0'
+      );
+
+      // no range
+      expect(getIncreasedLatestVersion(['1.5.0', '1.0.0'])).toStrictEqual(
+        '1.5.0'
+      );
+      expect(getIncreasedLatestVersion(['1.0.0', '1.0.0'])).toStrictEqual(
+        '1.0.0'
+      );
     });
   });
 });


### PR DESCRIPTION
Fixing `^1.0.0` and `1.5.0` should fix to `^1.5.0`, not `1.5.0`. This uses a safe, higher range instead of unnecessarily narrowing the range.

Fixes #353.

TODO:

- [x] More tests

Later, I would like to cleanup/refactor this implementation some more.