### PR TITLE
Mention competing offering Yarn Constraints in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Found 2 dependencies with mismatching versions across the workspace. Fix with `-
 ## Related
 
 * [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) — use this complementary tool to enforce that your dependency versions use consistent range types (i.e. [prefer-caret-version-dependencies](https://npmpackagejsonlint.org/docs/rules/dependencies/prefer-caret-version-dependencies), [prefer-caret-version-devDependencies](https://npmpackagejsonlint.org/docs/rules/dependencies/prefer-caret-version-devDependencies))
+* [Yarn Constraints](https://yarnpkg.com/features/constraints) - experimental built-in Yarn feature that can perform many workspace consistency checks
 
 ## References
 


### PR DESCRIPTION
[Yarn Constraints](https://yarnpkg.com/features/constraints) is an experimental feature built into newer versions of Yarn and offers many of the same workspace consistency checks that CDVC does, although I haven't done a thorough comparison of all the functionality. It appears to offer a lot of control and flexibility over the checks performed.

This confirms to us that there's clearly a lot of demand for the kind of functionality offered by CDVC. It could be an alternative to CDVC for some users, although it's not package-manager-agnostic like CDVC is (there's no NPM version of it to my knowledge).

Example usage:
* https://github.com/facebook/jest/blob/main/constraints.pro