### PR TITLE
Mention NPM workspaces in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Found 2 dependencies with mismatching versions across the workspace. Fix with `-
 
 ## References
 
-* [NPM Workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces)
-* [Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/)
+* [npm workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces)
+* [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/)
 
 [npm-image]: https://badge.fury.io/js/check-dependency-version-consistency.svg
 [npm-url]: https://www.npmjs.com/package/check-dependency-version-consistency

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version][npm-image]][npm-url]
 [![CI][ci-image]][ci-url]
 
-This CLI tool enforces the following aspects of consistency across a monorepo / yarn workspace:
+This CLI tool enforces the following aspects of consistency across a monorepo / NPM/Yarn workspace:
 
 1. Dependencies are on consistent versions. For example, every package in a workspace that has a dependency on `eslint` should specify the same version for it.
 2. Dependencies on local packages use the local packages directly instead of older versions of them. For example, if one package `package1` in a workspace depends on another package `package2` in the workspace, `package1` should request the current version of `package2`.
@@ -128,6 +128,7 @@ Found 2 dependencies with mismatching versions across the workspace. Fix with `-
 
 ## References
 
+* [NPM Workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces)
 * [Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/)
 
 [npm-image]: https://badge.fury.io/js/check-dependency-version-consistency.svg

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version][npm-image]][npm-url]
 [![CI][ci-image]][ci-url]
 
-This CLI tool enforces the following aspects of consistency across a monorepo / NPM/Yarn workspace:
+This CLI tool enforces the following aspects of consistency across a monorepo with npm or Yarn workspaces:
 
 1. Dependencies are on consistent versions. For example, every package in a workspace that has a dependency on `eslint` should specify the same version for it.
 2. Dependencies on local packages use the local packages directly instead of older versions of them. For example, if one package `package1` in a workspace depends on another package `package2` in the workspace, `package1` should request the current version of `package2`.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
     "dependencies",
     "linter",
     "monorepo",
+    "nodejs",
+    "npm",
     "package.json",
     "packages",
-    "workspace"
+    "workspace",
+    "yarn"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
NPM and Yarn both support the workspaces feature now.

Related:
* https://github.com/bmish/check-dependency-version-consistency/issues/545