### PR TITLE
Add Node API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install:
 yarn add --dev check-dependency-version-consistency
 ```
 
-To run, use this command and optionally pass the path to the workspace root (where the `package.json` file containing `workspaces` is located):
+To run, use this command and optionally pass the path to the workspace root (where the `package.json` file containing `workspaces` or `pnpm-workspace.yaml` is located):
 
 ```sh
 yarn check-dependency-version-consistency .
@@ -112,8 +112,10 @@ Found 2 dependencies with mismatching versions across the workspace. Fix with `-
 
 ## Options
 
+These options are available on the CLI and as parameters to the [Node API](#node-api).
+
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | `--fix` | Whether to autofix inconsistencies (using latest version present). |
 | `--ignore-dep` | Dependency to ignore mismatches for (option can be repeated). |
 | `--ignore-dep-pattern` | RegExp of dependency names to ignore mismatches for (option can be repeated). |
@@ -121,6 +123,57 @@ Found 2 dependencies with mismatching versions across the workspace. Fix with `-
 | `--ignore-package-pattern` | RegExp of package names to ignore mismatches for (option can be repeated). |
 | `--ignore-path` | Workspace-relative path of packages to ignore mismatches for (option can be repeated). |
 | `--ignore-path-pattern` | RegExp of workspace-relative path of packages to ignore mismatches for (option can be repeated). |
+
+## Node API
+
+```ts
+import { CDVC } from 'check-dependency-version-consistency';
+
+const cdvc = new CDVC(path, options);
+
+const result = cdvc.getDependency('eslint');
+
+// Result could look like this:
+const result = {
+  isFixable: true,
+  isMismatching: true,
+  name: 'eslint',
+  versions: [
+    {
+      packages: ['package1', 'package2'],
+      version: '^7.0.0',
+    },
+    {
+      packages: ['package3'],
+      version: '^8.0.0',
+    },
+  ],
+};
+```
+
+| [`CDVC`](./lib/cdvc.ts) Class Constructor Parameter | Type | Description |
+| :-- | :-- | :-- |
+| `path` | `string` | Path to the workspace root (where the `package.json` file containing `workspaces` or `pnpm-workspace.yaml` is located). |
+| `options` | `object` | See [Options](#options). |
+
+| [`CDVC`](./lib/cdvc.ts) Class Member | Description |
+| :-- | :-- |
+| `getDependencies()` | Returns an array of all dependencies in the workspace. |
+| `getDependency(name: string)` | Returns an object with information about an individual dependency. |
+| `hasMismatchingDependenciesFixable` | `true` if there are any dependencies with mismatching versions that are autofixable. |
+| `hasMismatchingDependenciesNotFixable` | `true` if there are any dependencies with mismatching versions that are not autofixable. |
+| `hasMismatchingDependencies` | `true` if there are any dependencies with mismatching versions. |
+| `toFixedSummary()` | Returns a string summary of the mismatching dependency versions that were fixed (if the `fix` option was specified). |
+| `toMismatchSummary()` | Returns a string of human-readable tables describing the mismatching dependency versions. |
+
+| Dependency Object Property | Description |
+| :-- | :-- |
+| `isFixable` | `true` if the mismatching versions of this dependency are autofixable. |
+| `isMismatching` | `true` if there are multiple versions of this dependency. |
+| `name` | The dependency's name. |
+| `versions` | A list of the versions present of this dependency and the packages each is found in, in the form of: `{ version: string, packages: string[] }`. The `packages` array has relative paths to each package. |
+
+See [`lib/cli.ts`](./lib/cli.ts) for an example of how to use it.
 
 ## Related
 

--- a/lib/cdvc.ts
+++ b/lib/cdvc.ts
@@ -1,0 +1,94 @@
+import { check } from './check.js';
+import {
+  dependenciesToFixedSummary,
+  dependenciesToMismatchSummary,
+} from './output.js';
+import { Dependencies } from './types.js';
+
+/** Relevant public data about a dependency. */
+type Dependency = {
+  name: string;
+  isFixable: boolean;
+  isMismatching: boolean;
+  versions: readonly {
+    version: string;
+    /** Relative path to each package.*/
+    packages: readonly string[];
+  }[];
+};
+
+export class CDVC {
+  /** An object mapping each dependency in the workspace to information including the versions found of it. */
+  private readonly dependencies: Dependencies;
+
+  /**
+   * @param path - path to the workspace root
+   * @param options
+   * @param options.fix - Whether to autofix inconsistencies (using latest version present)
+   * @param options.ignoreDep - Dependency(s) to ignore mismatches for
+   * @param options.ignoreDepPattern - RegExp(s) of dependency names to ignore mismatches for
+   * @param options.ignorePackage - Workspace package(s) to ignore mismatches for
+   * @param options.ignorePackagePattern - RegExp(s) of package names to ignore mismatches for
+   * @param options.ignorePath - Workspace-relative path(s) of packages to ignore mismatches for
+   * @param options.ignorePathPattern - RegExp(s) of workspace-relative path of packages to ignore mismatches for
+   */
+  constructor(
+    path: string,
+    options?: {
+      fix?: boolean;
+      ignoreDep?: readonly string[];
+      ignoreDepPattern?: readonly string[];
+      ignorePackage?: readonly string[];
+      ignorePackagePattern?: readonly string[];
+      ignorePath?: readonly string[];
+      ignorePathPattern?: readonly string[];
+    }
+  ) {
+    const { dependencies } = check(path, options);
+
+    this.dependencies = dependencies;
+  }
+
+  public toMismatchSummary(): string {
+    return dependenciesToMismatchSummary(this.dependencies);
+  }
+
+  public toFixedSummary(): string {
+    return dependenciesToFixedSummary(this.dependencies);
+  }
+
+  public getDependencies(): readonly Dependency[] {
+    return Object.keys(this.dependencies).map((dependency) =>
+      this.getDependency(dependency)
+    );
+  }
+
+  public getDependency(name: string): Dependency {
+    // Convert underlying dependency data object with relevant public data.
+    return {
+      name,
+      isFixable: this.dependencies[name].isFixable,
+      isMismatching: this.dependencies[name].isMismatching,
+      versions: this.dependencies[name].versions.map((version) => ({
+        version: version.version,
+        packages: version.packages.map((package_) => package_.pathRelative),
+      })),
+    };
+  }
+
+  public get hasMismatchingDependencies(): boolean {
+    return Object.values(this.dependencies).some((dep) => dep.isMismatching);
+  }
+
+  public get hasMismatchingDependenciesFixable(): boolean {
+    return Object.values(this.dependencies).some(
+      (dep) => dep.isMismatching && dep.isFixable
+    );
+  }
+
+  public get hasMismatchingDependenciesNotFixable(): boolean {
+    return Object.values(this.dependencies).some(
+      (dep) => dep.isMismatching && !dep.isFixable
+    );
+  }
+}

--- a/lib/check.ts
+++ b/lib/check.ts
@@ -1,0 +1,105 @@
+import {
+  calculateVersionsForEachDependency,
+  calculateDependenciesAndVersions,
+  filterOutIgnoredDependencies,
+  fixVersionsMismatching,
+} from './dependency-versions.js';
+import { Dependencies } from './types.js';
+import { getPackages } from './workspace.js';
+
+/**
+ * Checks for inconsistencies across a workspace. Optionally fixes them.
+ * @param path - path to the workspace root
+ * @param options
+ * @param options.fix - Whether to autofix inconsistencies (using latest version present)
+ * @param options.ignoreDep - Dependency(s) to ignore mismatches for
+ * @param options.ignoreDepPattern - RegExp(s) of dependency names to ignore mismatches for
+ * @param options.ignorePackage - Workspace package(s) to ignore mismatches for
+ * @param options.ignorePackagePattern - RegExp(s) of package names to ignore mismatches for
+ * @param options.ignorePath - Workspace-relative path(s) of packages to ignore mismatches for
+ * @param options.ignorePathPattern - RegExp(s) of workspace-relative path of packages to ignore mismatches for
+ * @returns an object with the following properties:
+ * - `dependencies`: An object mapping each dependency in the workspace to information about it including the versions found of it.
+ */
+export function check(
+  path: string,
+  options?: {
+    fix?: boolean;
+    ignoreDep?: readonly string[];
+    ignoreDepPattern?: readonly string[];
+    ignorePackage?: readonly string[];
+    ignorePackagePattern?: readonly string[];
+    ignorePath?: readonly string[];
+    ignorePathPattern?: readonly string[];
+  }
+): {
+  dependencies: Dependencies;
+} {
+  const optionsWithDefaults = {
+    fix: false,
+    ignoreDep: [],
+    ignoreDepPattern: [],
+    ignorePackage: [],
+    ignorePackagePattern: [],
+    ignorePath: [],
+    ignorePathPattern: [],
+    ...options,
+  };
+
+  // Calculate.
+  const packages = getPackages(
+    path,
+    optionsWithDefaults.ignorePackage,
+    optionsWithDefaults.ignorePackagePattern.map((s) => new RegExp(s)),
+    optionsWithDefaults.ignorePath,
+    optionsWithDefaults.ignorePathPattern.map((s) => new RegExp(s))
+  );
+
+  const dependencies = calculateVersionsForEachDependency(packages);
+  const dependenciesAndVersions =
+    calculateDependenciesAndVersions(dependencies);
+  const dependenciesAndVersionsWithMismatches = dependenciesAndVersions.filter(
+    ({ versions }) => versions.length > 1
+  );
+
+  // Information about all dependencies.
+  const dependenciesAndVersionsWithoutIgnored = filterOutIgnoredDependencies(
+    dependenciesAndVersions,
+    optionsWithDefaults.ignoreDep,
+    optionsWithDefaults.ignoreDepPattern.map((s) => new RegExp(s))
+  );
+
+  // Information about mismatches.
+  const dependenciesAndVersionsMismatchesWithoutIgnored =
+    filterOutIgnoredDependencies(
+      dependenciesAndVersionsWithMismatches,
+      optionsWithDefaults.ignoreDep,
+      optionsWithDefaults.ignoreDepPattern.map((s) => new RegExp(s))
+    );
+  const resultsAfterFix = fixVersionsMismatching(
+    packages,
+    dependenciesAndVersionsMismatchesWithoutIgnored,
+    !optionsWithDefaults.fix // Do dry-run if not fixing.
+  );
+  const versionsMismatchingFixable = resultsAfterFix.fixable;
+
+  return {
+    // Information about all dependencies.
+    dependencies: Object.fromEntries(
+      dependenciesAndVersionsWithoutIgnored.map(({ dependency, versions }) => {
+        return [
+          dependency,
+          {
+            isFixable: versionsMismatchingFixable.some(
+              (dep) => dep.dependency === dependency
+            ),
+            isMismatching: dependenciesAndVersionsMismatchesWithoutIgnored.some(
+              (dep) => dep.dependency === dependency
+            ),
+            versions,
+          },
+        ];
+      })
+    ),
+  };
+}

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,20 +1,9 @@
 import { Command, Argument } from 'commander';
 import { readFileSync } from 'node:fs';
-import {
-  calculateVersionsForEachDependency,
-  calculateMismatchingVersions,
-  filterOutIgnoredDependencies,
-  fixMismatchingVersions,
-  MismatchingDependencyVersions,
-} from '../lib/dependency-versions.js';
-import { getPackages } from '../lib/workspace.js';
-import {
-  mismatchingVersionsToOutput,
-  mismatchingVersionsFixedToOutput,
-} from '../lib/output.js';
 import { join, dirname } from 'node:path';
 import type { PackageJson } from 'type-fest';
 import { fileURLToPath } from 'node:url';
+import { CDVC } from './cdvc.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -29,7 +18,7 @@ function getCurrentPackageVersion(): string {
 }
 
 // Used for collecting repeated CLI options into an array.
-function collect(value: string, previous: string[]) {
+function collect(value: string, previous: readonly string[]) {
   return [...previous, value];
 }
 
@@ -81,53 +70,23 @@ export function run() {
       collect,
       []
     )
-    .action(function (
-      path,
-      options: {
-        ignoreDep: string[];
-        ignoreDepPattern: string[];
-        ignorePackage: string[];
-        ignorePackagePattern: string[];
-        ignorePath: string[];
-        ignorePathPattern: string[];
-        fix: boolean;
-      }
-    ) {
-      // Calculate.
-      const packages = getPackages(
-        path,
-        options.ignorePackage,
-        options.ignorePackagePattern.map((s) => new RegExp(s)),
-        options.ignorePath,
-        options.ignorePathPattern.map((s) => new RegExp(s))
-      );
-
-      const dependencyVersions = calculateVersionsForEachDependency(packages);
-
-      let mismatchingVersions = filterOutIgnoredDependencies(
-        calculateMismatchingVersions(dependencyVersions),
-        options.ignoreDep,
-        options.ignoreDepPattern.map((s) => new RegExp(s))
-      );
-      let mismatchingVersionsFixed: MismatchingDependencyVersions = [];
+    .action((path, options) => {
+      const cdvc = new CDVC(path, options);
 
       if (options.fix) {
-        const resultsAfterFix = fixMismatchingVersions(
-          packages,
-          mismatchingVersions
-        );
-        mismatchingVersions = resultsAfterFix.notFixed;
-        mismatchingVersionsFixed = resultsAfterFix.fixed;
-      }
+        // Show output for dependencies we fixed.
+        if (cdvc.hasMismatchingDependenciesFixable) {
+          console.log(cdvc.toFixedSummary());
+        }
 
-      // Show output for dependencies we fixed.
-      if (mismatchingVersionsFixed.length > 0) {
-        console.log(mismatchingVersionsFixedToOutput(mismatchingVersionsFixed));
-      }
-
-      // Show output for dependencies that still have mismatches.
-      if (mismatchingVersions.length > 0) {
-        console.log(mismatchingVersionsToOutput(mismatchingVersions));
+        // Show output for dependencies that still have mismatches.
+        if (cdvc.hasMismatchingDependenciesNotFixable) {
+          console.log(cdvc.toMismatchSummary());
+          process.exitCode = 1;
+        }
+      } else if (cdvc.hasMismatchingDependencies) {
+        // Show output for dependencies that have mismatches.
+        console.log(cdvc.toMismatchSummary());
         process.exitCode = 1;
       }
     })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,3 @@
+// Public Node API.
+
+export { CDVC } from './cdvc.js';

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,14 +1,21 @@
 import chalk from 'chalk';
-import type { MismatchingDependencyVersions } from './dependency-versions.js';
 import {
   compareVersionRangesSafe,
   getIncreasedLatestVersion,
 } from './semver.js';
 import { table } from 'table';
+import { Dependencies } from './types.js';
 
-export function mismatchingVersionsToOutput(
-  mismatchingDependencyVersions: MismatchingDependencyVersions
+/**
+ * Returns human-readable tables describing mismatching dependency versions.
+ */
+export function dependenciesToMismatchSummary(
+  dependencies: Dependencies
 ): string {
+  const mismatchingDependencyVersions = Object.entries(dependencies)
+    .filter(([, value]) => value.isMismatching)
+    .map(([dependency, value]) => ({ dependency, versions: value.versions }));
+
   if (mismatchingDependencyVersions.length === 0) {
     throw new Error('No mismatching versions to output.');
   }
@@ -25,7 +32,7 @@ export function mismatchingVersionsToOutput(
         (count) => count === latestUsageCount
       );
 
-      const rows = object.versions
+      const rows = [...object.versions]
         .sort((a, b) => compareVersionRangesSafe(b.version, a.version))
         .map((versionObject) => {
           const usageCount = versionObject.packages.length;
@@ -59,9 +66,14 @@ export function mismatchingVersionsToOutput(
   ].join('\n');
 }
 
-export function mismatchingVersionsFixedToOutput(
-  mismatchingDependencyVersions: MismatchingDependencyVersions
-): string {
+/**
+ * Returns a summary of the mismatching dependency versions that were fixed.
+ */
+export function dependenciesToFixedSummary(dependencies: Dependencies): string {
+  const mismatchingDependencyVersions = Object.entries(dependencies)
+    .filter(([, value]) => value.isMismatching)
+    .map(([dependency, value]) => ({ dependency, versions: value.versions }));
+
   if (mismatchingDependencyVersions.length === 0) {
     throw new Error('No fixes to output.');
   }

--- a/lib/package.ts
+++ b/lib/package.ts
@@ -3,14 +3,19 @@ import { join, relative } from 'node:path';
 import { PackageJson } from 'type-fest';
 import { load } from 'js-yaml';
 
-// Class to represent all of the information we need to know about a package in a workspace.
+/*
+ * Class to represent all of the information we need to know about a package in a workspace.
+ */
 export class Package {
-  path: string; // Absolute path to package.
-  pathWorkspace: string; // Absolute path to workspace.
-  pathPackageJson: string; // Absolute path to package.json.
+  /** Absolute path to package */
+  path: string;
+  /** Absolute path to workspace.*/
+  pathWorkspace: string;
+  /** Absolute path to package.json. */
+  pathPackageJson: string;
   packageJson: PackageJson;
   packageJsonEndsInNewline: boolean;
-  pnpmWorkspacePackages?: string[];
+  pnpmWorkspacePackages?: readonly string[];
 
   constructor(path: string, pathWorkspace: string) {
     this.path = path;
@@ -27,13 +32,13 @@ export class Package {
     if (existsSync(pnpmWorkspacePath)) {
       const pnpmWorkspaceContents = readFileSync(pnpmWorkspacePath, 'utf8');
       const pnpmWorkspaceYaml = load(pnpmWorkspaceContents) as {
-        packages?: string[];
+        packages?: readonly string[];
       };
       this.pnpmWorkspacePackages = pnpmWorkspaceYaml.packages;
     }
   }
 
-  get name() {
+  get name(): string {
     if (this.workspacePatterns.length > 0 && !this.packageJson.name) {
       return '(Root)';
     }
@@ -43,12 +48,12 @@ export class Package {
     return this.packageJson.name;
   }
 
-  // Relative to workspace root.
-  get pathRelative() {
+  /** Relative to workspace root. */
+  get pathRelative(): string {
     return relative(this.pathWorkspace, this.path);
   }
 
-  get workspacePatterns(): string[] {
+  get workspacePatterns(): readonly string[] {
     if (this.packageJson.workspaces) {
       if (Array.isArray(this.packageJson.workspaces)) {
         return this.packageJson.workspaces;
@@ -76,12 +81,15 @@ export class Package {
     return [];
   }
 
-  static exists(path: string) {
+  static exists(path: string): boolean {
     const packageJsonPath = join(path, 'package.json');
     return existsSync(packageJsonPath);
   }
 
-  static some(packages: Package[], callback: (package_: Package) => boolean) {
+  static some(
+    packages: readonly Package[],
+    callback: (package_: Package) => boolean
+  ): boolean {
     return packages.some((package_) => callback(package_));
   }
 

--- a/lib/semver.ts
+++ b/lib/semver.ts
@@ -52,19 +52,19 @@ export function versionRangeToRange(versionRange: string): string {
   return match ? match[0] : '';
 }
 
-export function getLatestVersion(versions: string[]): string {
-  const sortedVersions = versions.sort(compareVersionRanges);
+export function getLatestVersion(versions: readonly string[]): string {
+  const sortedVersions = [...versions].sort(compareVersionRanges);
   return sortedVersions[sortedVersions.length - 1]; // Latest version will be sorted to end of list.
 }
 
 // Example input: ['~', '^'], output: '^'
-export function getHighestRangeType(ranges: string[]): string {
-  const sorted = ranges.sort(compareRanges);
+export function getHighestRangeType(ranges: readonly string[]): string {
+  const sorted = [...ranges].sort(compareRanges);
   return sorted[sorted.length - 1]; // Range with highest precedence will be sorted to end of list.
 }
 
 // Example input: ['1.5.0', '^1.0.0'], output: '^1.5.0'
-export function getIncreasedLatestVersion(versions: string[]): string {
+export function getIncreasedLatestVersion(versions: readonly string[]): string {
   const latestVersion = getLatestVersion(versions);
   const latestVersionBare = semver.coerce(latestVersion);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,14 @@
+import { Package } from './package.js';
+
+/** Map of dependency name to information about the dependency. */
+export type Dependencies = Record<
+  string,
+  {
+    isFixable: boolean;
+    isMismatching: boolean;
+    versions: readonly {
+      version: string;
+      packages: readonly Package[];
+    }[];
+  }
+>;

--- a/lib/workspace.ts
+++ b/lib/workspace.ts
@@ -4,11 +4,11 @@ import { Package } from './package.js';
 
 export function getPackages(
   root: string,
-  ignorePackages: string[],
-  ignorePackagePatterns: RegExp[],
-  ignorePaths: string[],
-  ignorePathPatterns: RegExp[]
-): Package[] {
+  ignorePackages: readonly string[],
+  ignorePackagePatterns: readonly RegExp[],
+  ignorePaths: readonly string[],
+  ignorePathPatterns: readonly RegExp[]
+): readonly Package[] {
   // Check for some error cases first.
   if (!Package.exists(root)) {
     throw new Error('No package.json found at provided path.');
@@ -94,7 +94,10 @@ export function getPackages(
 }
 
 // Expand workspace globs into concrete paths.
-function expandWorkspaces(root: string, workspacePatterns: string[]): string[] {
+function expandWorkspaces(
+  root: string,
+  workspacePatterns: readonly string[]
+): readonly string[] {
   return workspacePatterns.flatMap((workspace) => {
     if (!workspace.includes('*')) {
       return [workspace];
@@ -110,7 +113,10 @@ function expandWorkspaces(root: string, workspacePatterns: string[]): string[] {
 }
 
 // Recursively collect packages from a workspace.
-function accumulatePackages(root: string, paths: string[]): Package[] {
+function accumulatePackages(
+  root: string,
+  paths: readonly string[]
+): readonly Package[] {
   const results = [];
   for (const relativePath of paths) {
     const path = join(root, relativePath);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "license": "MIT",
   "type": "module",
+  "exports": "./dist/lib/index.js",
+  "main": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
   "bin": {
     "check-dependency-version-consistency": "dist/bin/check-dependency-version-consistency.js"
   },

--- a/test/fixtures/valid-with-workspace-prefix/package2/package.json
+++ b/test/fixtures/valid-with-workspace-prefix/package2/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "package2",
     "dependencies": {
         "package1": "workspace:*"
     }

--- a/test/lib/cdvc-test.ts
+++ b/test/lib/cdvc-test.ts
@@ -1,0 +1,446 @@
+import {
+  FIXTURE_PATH_INCONSISTENT_VERSIONS,
+  FIXTURE_PATH_VALID,
+} from '../fixtures/index.js';
+import { CDVC } from '../../lib/cdvc.js';
+import mockFs from 'mock-fs';
+import { readFileSync } from 'node:fs';
+import type { PackageJson } from 'type-fest';
+import path from 'node:path';
+
+describe('CDVC', function () {
+  describe('valid fixture', function () {
+    it('behaves correctly', function () {
+      const cdvc = new CDVC(FIXTURE_PATH_VALID);
+      const dependencies = cdvc.getDependencies();
+
+      expect(cdvc.hasMismatchingDependencies).toBe(false);
+      expect(cdvc.hasMismatchingDependenciesFixable).toBe(false);
+      expect(cdvc.hasMismatchingDependenciesNotFixable).toBe(false);
+      expect(dependencies).toStrictEqual([
+        {
+          isFixable: false,
+          isMismatching: false,
+          name: 'bar',
+          versions: [
+            {
+              packages: [
+                path.join('@scope1', 'package1'),
+                path.join('@scope1', 'package2'),
+                path.join('@scope2', 'deps-only'),
+                'package1',
+              ],
+              version: '^4.5.6',
+            },
+          ],
+        },
+        {
+          isFixable: false,
+          isMismatching: false,
+          name: 'baz',
+          versions: [
+            {
+              packages: [
+                path.join('@scope1', 'package1'),
+                path.join('@scope1', 'package2'),
+                path.join('@scope2', 'dev-deps-only'),
+                'package1',
+              ],
+              version: '^7.8.9',
+            },
+          ],
+        },
+        {
+          isFixable: false,
+          isMismatching: false,
+          name: 'foo',
+          versions: [
+            {
+              packages: [
+                '',
+                path.join('@scope1', 'package1'),
+                path.join('@scope1', 'package2'),
+                path.join('@scope2', 'deps-only'),
+                'package1',
+              ],
+              version: '1.2.3',
+            },
+          ],
+        },
+        {
+          isFixable: false,
+          isMismatching: false,
+          name: 'foo1',
+          versions: [
+            {
+              packages: ['package1'],
+              version: '^1.0.0',
+            },
+          ],
+        },
+      ]);
+
+      // Generated property.
+      expect(dependencies.map((dep) => dep.isMismatching)).toStrictEqual([
+        false,
+        false,
+        false,
+        false,
+      ]);
+
+      expect(cdvc.getDependency('foo')).toStrictEqual({
+        isFixable: false,
+        isMismatching: false,
+        name: 'foo',
+        versions: [
+          {
+            packages: [
+              '',
+              path.join('@scope1', 'package1'),
+              path.join('@scope1', 'package2'),
+              path.join('@scope2', 'deps-only'),
+              'package1',
+            ],
+            version: '1.2.3',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('invalid fixture', function () {
+    it('behaves correctly', function () {
+      const cdvc = new CDVC(FIXTURE_PATH_INCONSISTENT_VERSIONS);
+      const dependencies = cdvc.getDependencies();
+
+      expect(cdvc.hasMismatchingDependencies).toBe(true);
+      expect(cdvc.hasMismatchingDependenciesFixable).toBe(true);
+      expect(cdvc.hasMismatchingDependenciesNotFixable).toBe(false);
+      expect(dependencies).toStrictEqual([
+        {
+          isFixable: false,
+          isMismatching: false,
+          name: 'bar',
+          versions: [
+            {
+              packages: [
+                path.join('@scope1', 'package1'),
+                path.join('@scope1', 'package2'),
+              ],
+              version: '^4.5.6',
+            },
+          ],
+        },
+        {
+          isFixable: true,
+          isMismatching: true,
+          name: 'baz',
+          versions: [
+            {
+              packages: [path.join('@scope1', 'package1')],
+              version: '^7.8.9',
+            },
+            {
+              packages: [path.join('@scope1', 'package2')],
+              version: '^8.0.0',
+            },
+          ],
+        },
+        {
+          isFixable: true,
+          isMismatching: true,
+          name: 'foo',
+          versions: [
+            {
+              packages: [
+                '',
+                path.join('@scope1', 'package2'),
+                path.join('@scope1', 'package3'),
+              ],
+              version: '1.2.0',
+            },
+            {
+              packages: [path.join('@scope1', 'package1')],
+              version: '1.3.0',
+            },
+          ],
+        },
+      ]);
+
+      // Generated property.
+      expect(dependencies.map((dep) => dep.isMismatching)).toStrictEqual([
+        false,
+        true,
+        true,
+      ]);
+    });
+  });
+
+  describe('invalid fixture and ignore patterns', function () {
+    it('behaves correctly', function () {
+      const cdvc = new CDVC(FIXTURE_PATH_INCONSISTENT_VERSIONS, {
+        ignorePackagePattern: ['package3'],
+        ignorePathPattern: ['package3'],
+        ignoreDepPattern: ['foo'],
+      });
+      const dependencies = cdvc.getDependencies();
+
+      expect(cdvc.hasMismatchingDependencies).toBe(true);
+      expect(cdvc.hasMismatchingDependenciesFixable).toBe(true);
+      expect(cdvc.hasMismatchingDependenciesNotFixable).toBe(false);
+      expect(dependencies).toStrictEqual([
+        {
+          isFixable: false,
+          isMismatching: false,
+          name: 'bar',
+          versions: [
+            {
+              packages: [
+                path.join('@scope1', 'package1'),
+                path.join('@scope1', 'package2'),
+              ],
+              version: '^4.5.6',
+            },
+          ],
+        },
+        {
+          isFixable: true,
+          isMismatching: true,
+          name: 'baz',
+          versions: [
+            {
+              packages: [path.join('@scope1', 'package1')],
+              version: '^7.8.9',
+            },
+            {
+              packages: [path.join('@scope1', 'package2')],
+              version: '^8.0.0',
+            },
+          ],
+        },
+      ]);
+
+      // Generated property.
+      expect(dependencies.map((dep) => dep.isMismatching)).toStrictEqual([
+        false,
+        true,
+      ]);
+    });
+  });
+
+  describe('mocking the filesystem, with an unfixable version', function () {
+    let expectedPackage1: PackageJson;
+    let expectedPackage2: PackageJson;
+    beforeEach(function () {
+      // Create a mock workspace filesystem for temporary usage in this test because changes will be written to some files.
+      expectedPackage1 = {
+        name: 'package1',
+        dependencies: {
+          foo: '^1.0.0',
+        },
+      };
+      expectedPackage2 = {
+        name: 'package2',
+        dependencies: {
+          foo: '*',
+        },
+      };
+      mockFs({
+        'package.json': JSON.stringify({
+          workspaces: ['*'],
+        }),
+        package1: {
+          'package.json': JSON.stringify(expectedPackage1),
+        },
+        package2: {
+          'package.json': JSON.stringify(expectedPackage2),
+        },
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('does not fix because of unfixable version and returns the unfixable list', function () {
+      const cdvc = new CDVC('.', { fix: true });
+
+      expect(cdvc.getDependencies()).toStrictEqual([
+        {
+          isFixable: false,
+          isMismatching: true,
+          name: 'foo',
+          versions: [
+            {
+              packages: ['package1'],
+              version: '^1.0.0',
+            },
+            {
+              packages: ['package2'],
+              version: '*',
+            },
+          ],
+        },
+      ]);
+
+      // Read in package.json files.
+      const packageJson1Contents = readFileSync(
+        'package1/package.json',
+        'utf8'
+      );
+      const packageJson2Contents = readFileSync(
+        'package2/package.json',
+        'utf8'
+      );
+      const actualPackageJson1: PackageJson = JSON.parse(packageJson1Contents);
+      const actualPackageJson2: PackageJson = JSON.parse(packageJson2Contents);
+
+      expect(actualPackageJson1).toStrictEqual(expectedPackage1);
+      expect(actualPackageJson2).toStrictEqual(expectedPackage2);
+    });
+  });
+
+  describe('mocking the filesystem, without fixing', function () {
+    let expectedPackage1: PackageJson;
+    let expectedPackage2: PackageJson;
+    beforeEach(function () {
+      // Create a mock workspace filesystem for temporary usage in this test because changes will be written to some files.
+      expectedPackage1 = {
+        name: 'package1',
+        dependencies: {
+          foo: '^1.0.0',
+        },
+      };
+      expectedPackage2 = {
+        name: 'package2',
+        dependencies: {
+          foo: '1.5.0',
+        },
+      };
+      mockFs({
+        'package.json': JSON.stringify({
+          workspaces: ['*'],
+        }),
+        package1: {
+          'package.json': JSON.stringify(expectedPackage1),
+        },
+        package2: {
+          'package.json': JSON.stringify(expectedPackage2),
+        },
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('does not fix by default', function () {
+      const cdvc = new CDVC('.');
+
+      expect(cdvc.getDependencies()).toStrictEqual([
+        {
+          isFixable: true,
+          isMismatching: true,
+          name: 'foo',
+          versions: [
+            {
+              packages: ['package1'],
+              version: '^1.0.0',
+            },
+            {
+              packages: ['package2'],
+              version: '1.5.0',
+            },
+          ],
+        },
+      ]);
+
+      // Read in package.json files.
+      const packageJson1Contents = readFileSync(
+        'package1/package.json',
+        'utf8'
+      );
+      const packageJson2Contents = readFileSync(
+        'package2/package.json',
+        'utf8'
+      );
+      const actualPackageJson1: PackageJson = JSON.parse(packageJson1Contents);
+      const actualPackageJson2: PackageJson = JSON.parse(packageJson2Contents);
+
+      expect(actualPackageJson1).toStrictEqual(expectedPackage1);
+      expect(actualPackageJson2).toStrictEqual(expectedPackage2);
+    });
+  });
+
+  describe('mocking the filesystem, with fixing', function () {
+    beforeEach(function () {
+      // Create a mock workspace filesystem for temporary usage in this test because changes will be written to some files.
+      mockFs({
+        'package.json': JSON.stringify({
+          workspaces: ['*'],
+        }),
+        package1: {
+          'package.json': JSON.stringify({
+            name: 'package1',
+            dependencies: {
+              foo: '^1.0.0',
+            },
+          }),
+        },
+        package2: {
+          'package.json': JSON.stringify({
+            name: 'package2',
+            dependencies: {
+              foo: '1.5.0',
+            },
+          }),
+        },
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('fixes when option provided', function () {
+      const cdvc = new CDVC('.', { fix: true });
+
+      expect(cdvc.getDependencies()).toStrictEqual([
+        {
+          isFixable: true,
+          isMismatching: true,
+          name: 'foo',
+          versions: [
+            {
+              packages: ['package1'],
+              version: '^1.0.0',
+            },
+            {
+              packages: ['package2'],
+              version: '1.5.0',
+            },
+          ],
+        },
+      ]);
+
+      // Read in package.json files.
+      const packageJson1Contents = readFileSync(
+        'package1/package.json',
+        'utf8'
+      );
+      const packageJson2Contents = readFileSync(
+        'package2/package.json',
+        'utf8'
+      );
+      const actualPackageJson1: PackageJson = JSON.parse(packageJson1Contents);
+      const actualPackageJson2: PackageJson = JSON.parse(packageJson2Contents);
+
+      expect(
+        actualPackageJson1.dependencies && actualPackageJson1.dependencies.foo
+      ).toStrictEqual('^1.5.0');
+      expect(
+        actualPackageJson2.dependencies && actualPackageJson2.dependencies.foo
+      ).toStrictEqual('^1.5.0');
+    });
+  });
+});

--- a/test/lib/output-test.ts
+++ b/test/lib/output-test.ts
@@ -1,30 +1,16 @@
 import {
-  calculateVersionsForEachDependency,
-  calculateMismatchingVersions,
-} from '../../lib/dependency-versions.js';
-import {
-  mismatchingVersionsToOutput,
-  mismatchingVersionsFixedToOutput,
-} from '../../lib/output.js';
-import { getPackages } from '../../lib/workspace.js';
-import {
   FIXTURE_PATH_TESTING_OUTPUT,
   FIXTURE_PATH_NAMES_NOT_MATCHING_LOCATIONS,
   FIXTURE_PATH_INCREASABLE_RANGE,
+  FIXTURE_PATH_VALID,
 } from '../fixtures/index.js';
+import { CDVC } from '../../lib/cdvc.js';
 
 describe('Utils | output', function () {
-  describe('#mismatchingVersionsToOutputLines', function () {
+  describe('#dependenciesToMismatchSummary', function () {
     it('behaves correctly', function () {
-      expect(
-        mismatchingVersionsToOutput(
-          calculateMismatchingVersions(
-            calculateVersionsForEachDependency(
-              getPackages(FIXTURE_PATH_TESTING_OUTPUT, [], [], [], [])
-            )
-          )
-        )
-      ).toMatchInlineSnapshot(`
+      const cdvc = new CDVC(FIXTURE_PATH_TESTING_OUTPUT);
+      expect(cdvc.toMismatchSummary()).toMatchInlineSnapshot(`
         "Found 4 dependencies with mismatching versions across the workspace. Fix with \`--fix\`.
         ╔═══════╤════════╤════════════════════════════════════════════╗
         ║ [1mbar[22m   │ Usages │ Packages                                   ║
@@ -61,21 +47,8 @@ describe('Utils | output', function () {
     });
 
     it('behaves correctly when package names do not match locations', function () {
-      expect(
-        mismatchingVersionsToOutput(
-          calculateMismatchingVersions(
-            calculateVersionsForEachDependency(
-              getPackages(
-                FIXTURE_PATH_NAMES_NOT_MATCHING_LOCATIONS,
-                [],
-                [],
-                [],
-                []
-              )
-            )
-          )
-        )
-      ).toMatchInlineSnapshot(`
+      const cdvc = new CDVC(FIXTURE_PATH_NAMES_NOT_MATCHING_LOCATIONS);
+      expect(cdvc.toMismatchSummary()).toMatchInlineSnapshot(`
         "Found 1 dependency with mismatching versions across the workspace. Fix with \`--fix\`.
         ╔═══════╤════════╤══════════════════════════╗
         ║ [1mfoo[22m   │ Usages │ Packages                 ║
@@ -89,57 +62,40 @@ describe('Utils | output', function () {
     });
 
     it('behaves correctly with empty input', function () {
-      expect(() =>
-        mismatchingVersionsToOutput([])
-      ).toThrowErrorMatchingInlineSnapshot(
+      const cdvc = new CDVC(FIXTURE_PATH_VALID);
+      expect(() => cdvc.toMismatchSummary()).toThrowErrorMatchingInlineSnapshot(
         '"No mismatching versions to output."'
       );
     });
   });
 
-  describe('#mismatchingVersionsFixedToOutputLines', function () {
+  describe('#dependenciesToFixedSummary', function () {
     it('behaves correctly', function () {
-      expect(
-        mismatchingVersionsFixedToOutput(
-          calculateMismatchingVersions(
-            calculateVersionsForEachDependency(
-              getPackages(FIXTURE_PATH_TESTING_OUTPUT, [], [], [], [])
-            )
-          )
-        )
-      ).toMatchInlineSnapshot(
+      const cdvc = new CDVC(FIXTURE_PATH_TESTING_OUTPUT);
+      expect(cdvc.toFixedSummary()).toMatchInlineSnapshot(
         '"Fixed versions for 3 dependencies: bar@2.0.0, baz@^2.0.0, foo@4.5.6"'
       );
     });
 
     it('behaves correctly with a single fix', function () {
-      expect(
-        mismatchingVersionsFixedToOutput(
-          calculateMismatchingVersions(
-            calculateVersionsForEachDependency(
-              getPackages(FIXTURE_PATH_TESTING_OUTPUT, [], [], [], [])
-            )
-          ).slice(0, 1)
-        )
-      ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: bar@2.0.0"');
+      const cdvc = new CDVC(FIXTURE_PATH_INCREASABLE_RANGE);
+      expect(cdvc.toFixedSummary()).toMatchInlineSnapshot(
+        '"Fixed versions for 1 dependency: foo@^1.5.0"'
+      );
     });
 
     it('behaves correctly with an increasable range', function () {
-      expect(
-        mismatchingVersionsFixedToOutput(
-          calculateMismatchingVersions(
-            calculateVersionsForEachDependency(
-              getPackages(FIXTURE_PATH_INCREASABLE_RANGE, [], [], [], [])
-            )
-          ).slice(0, 1)
-        )
-      ).toMatchInlineSnapshot('"Fixed versions for 1 dependency: foo@^1.5.0"');
+      const cdvc = new CDVC(FIXTURE_PATH_INCREASABLE_RANGE);
+      expect(cdvc.toFixedSummary()).toMatchInlineSnapshot(
+        '"Fixed versions for 1 dependency: foo@^1.5.0"'
+      );
     });
 
     it('behaves correctly with empty input', function () {
-      expect(() =>
-        mismatchingVersionsFixedToOutput([])
-      ).toThrowErrorMatchingInlineSnapshot('"No fixes to output."');
+      const cdvc = new CDVC(FIXTURE_PATH_VALID);
+      expect(() => cdvc.toFixedSummary()).toThrowErrorMatchingInlineSnapshot(
+        '"No fixes to output."'
+      );
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,7 +424,7 @@
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
-"@jest/globals@^27.5.1":
+"@jest/globals@^27.0.0", "@jest/globals@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.1.tgz#7ac06ce57ab966566c7963431cef458434601b2b"
   integrity sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==


### PR DESCRIPTION
Fixes #204.

See the README for more info.

Includes various refactorings:
* Data models
* readonly arrays

TODO

* Cleanup `check()` function
* Stop testing so many internal helper functions in `test/lib/dependency-versions-test.ts` as this makes it hard to refactor. Test using the public CDVC API instead.