### PR TITLE
Consider `optionalDependencies` by default

### DIFF
--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -3,5 +3,7 @@ import { DEPENDENCY_TYPE } from './types.js';
 export const DEFAULT_DEP_TYPES = [
   DEPENDENCY_TYPE.dependencies,
   DEPENDENCY_TYPE.devDependencies,
+  DEPENDENCY_TYPE.optionalDependencies,
   DEPENDENCY_TYPE.resolutions,
+  // peerDependencies is not included by default, see discussion in: https://github.com/bmish/check-dependency-version-consistency/issues/402
 ];

--- a/test/lib/cdvc-test.ts
+++ b/test/lib/cdvc-test.ts
@@ -323,11 +323,6 @@ describe('CDVC', function () {
         it('fixes the fixable inconsistencies', function () {
           const cdvc = new CDVC('.', {
             fix: true,
-            depType: [
-              DEPENDENCY_TYPE.optionalDependencies,
-              DEPENDENCY_TYPE.devDependencies,
-              DEPENDENCY_TYPE.dependencies,
-            ],
           });
 
           // Read in package.json files.


### PR DESCRIPTION
Part of #346.

Fixes https://github.com/bmish/check-dependency-version-consistency/issues/603.