### PR TITLE
Use object instead of string to represent package in Node API

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ const result = {
   name: 'eslint',
   versions: [
     {
-      packages: ['package1', 'package2'],
+      packages: [{ pathRelative: 'package1' }, { pathRelative: 'package2' }],
       version: '^7.0.0',
     },
     {
-      packages: ['package3'],
+      packages: [{ pathRelative: 'package3' }],
       version: '^8.0.0',
     },
   ],
@@ -172,7 +172,7 @@ const result = {
 | `isFixable` | `true` if the mismatching versions of this dependency are autofixable. |
 | `isMismatching` | `true` if there are multiple versions of this dependency. |
 | `name` | The dependency's name. |
-| `versions` | A list of the versions present of this dependency and the packages each is found in, in the form of: `{ version: string, packages: string[] }`. The `packages` array has relative paths to each package. |
+| `versions` | A list of the versions present of this dependency and the packages each is found in, in the form of: `{ version: string, packages: { pathRelative: string }[] }`. |
 
 See [`lib/cli.ts`](./lib/cli.ts) for an example of how to use it.
 

--- a/lib/cdvc.ts
+++ b/lib/cdvc.ts
@@ -12,8 +12,7 @@ type Dependency = {
   isMismatching: boolean;
   versions: readonly {
     version: string;
-    /** Relative path to each package.*/
-    packages: readonly string[];
+    packages: readonly { pathRelative: string }[];
   }[];
 };
 
@@ -60,7 +59,9 @@ export class CDVC {
       isMismatching: this.dependencies[name].isMismatching,
       versions: this.dependencies[name].versions.map((version) => ({
         version: version.version,
-        packages: version.packages.map((package_) => package_.pathRelative),
+        packages: version.packages.map((package_) => ({
+          pathRelative: package_.pathRelative,
+        })),
       })),
     };
   }

--- a/test/lib/cdvc-test.ts
+++ b/test/lib/cdvc-test.ts
@@ -29,10 +29,10 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                path.join('@scope1', 'package1'),
-                path.join('@scope1', 'package2'),
-                path.join('@scope2', 'deps-only'),
-                'package1',
+                { pathRelative: path.join('@scope1', 'package1') },
+                { pathRelative: path.join('@scope1', 'package2') },
+                { pathRelative: path.join('@scope2', 'deps-only') },
+                { pathRelative: 'package1' },
               ],
               version: '^4.5.6',
             },
@@ -45,10 +45,10 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                path.join('@scope1', 'package1'),
-                path.join('@scope1', 'package2'),
-                path.join('@scope2', 'dev-deps-only'),
-                'package1',
+                { pathRelative: path.join('@scope1', 'package1') },
+                { pathRelative: path.join('@scope1', 'package2') },
+                { pathRelative: path.join('@scope2', 'dev-deps-only') },
+                { pathRelative: 'package1' },
               ],
               version: '^7.8.9',
             },
@@ -61,11 +61,11 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                '',
-                path.join('@scope1', 'package1'),
-                path.join('@scope1', 'package2'),
-                path.join('@scope2', 'deps-only'),
-                'package1',
+                { pathRelative: '' },
+                { pathRelative: path.join('@scope1', 'package1') },
+                { pathRelative: path.join('@scope1', 'package2') },
+                { pathRelative: path.join('@scope2', 'deps-only') },
+                { pathRelative: 'package1' },
               ],
               version: '1.2.3',
             },
@@ -77,7 +77,7 @@ describe('CDVC', function () {
           name: 'foo1',
           versions: [
             {
-              packages: ['package1'],
+              packages: [{ pathRelative: 'package1' }],
               version: '^1.0.0',
             },
           ],
@@ -91,11 +91,11 @@ describe('CDVC', function () {
         versions: [
           {
             packages: [
-              '',
-              path.join('@scope1', 'package1'),
-              path.join('@scope1', 'package2'),
-              path.join('@scope2', 'deps-only'),
-              'package1',
+              { pathRelative: '' },
+              { pathRelative: path.join('@scope1', 'package1') },
+              { pathRelative: path.join('@scope1', 'package2') },
+              { pathRelative: path.join('@scope2', 'deps-only') },
+              { pathRelative: 'package1' },
             ],
             version: '1.2.3',
           },
@@ -120,8 +120,8 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                path.join('@scope1', 'package1'),
-                path.join('@scope1', 'package2'),
+                { pathRelative: path.join('@scope1', 'package1') },
+                { pathRelative: path.join('@scope1', 'package2') },
               ],
               version: '^4.5.6',
             },
@@ -133,11 +133,11 @@ describe('CDVC', function () {
           name: 'baz',
           versions: [
             {
-              packages: [path.join('@scope1', 'package1')],
+              packages: [{ pathRelative: path.join('@scope1', 'package1') }],
               version: '^7.8.9',
             },
             {
-              packages: [path.join('@scope1', 'package2')],
+              packages: [{ pathRelative: path.join('@scope1', 'package2') }],
               version: '^8.0.0',
             },
           ],
@@ -149,14 +149,14 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                '',
-                path.join('@scope1', 'package2'),
-                path.join('@scope1', 'package3'),
+                { pathRelative: '' },
+                { pathRelative: path.join('@scope1', 'package2') },
+                { pathRelative: path.join('@scope1', 'package3') },
               ],
               version: '1.2.0',
             },
             {
-              packages: [path.join('@scope1', 'package1')],
+              packages: [{ pathRelative: path.join('@scope1', 'package1') }],
               version: '1.3.0',
             },
           ],
@@ -183,11 +183,11 @@ describe('CDVC', function () {
             name: 'baz',
             versions: [
               {
-                packages: [path.join('@scope1', 'package1')],
+                packages: [{ pathRelative: path.join('@scope1', 'package1') }],
                 version: '^7.8.9',
               },
               {
-                packages: [path.join('@scope1', 'package2')],
+                packages: [{ pathRelative: path.join('@scope1', 'package2') }],
                 version: '^8.0.0',
               },
             ],
@@ -198,7 +198,7 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '1.2.0',
               },
             ],
@@ -225,8 +225,8 @@ describe('CDVC', function () {
             versions: [
               {
                 packages: [
-                  path.join('@scope1', 'package1'),
-                  path.join('@scope1', 'package2'),
+                  { pathRelative: path.join('@scope1', 'package1') },
+                  { pathRelative: path.join('@scope1', 'package2') },
                 ],
                 version: '^4.5.6',
               },
@@ -239,13 +239,13 @@ describe('CDVC', function () {
             versions: [
               {
                 packages: [
-                  path.join('@scope1', 'package2'),
-                  path.join('@scope1', 'package3'),
+                  { pathRelative: path.join('@scope1', 'package2') },
+                  { pathRelative: path.join('@scope1', 'package3') },
                 ],
                 version: '1.2.0',
               },
               {
-                packages: [path.join('@scope1', 'package1')],
+                packages: [{ pathRelative: path.join('@scope1', 'package1') }],
                 version: '1.3.0',
               },
             ],
@@ -271,7 +271,7 @@ describe('CDVC', function () {
             name: 'bar',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '^1.0.0',
               },
             ],
@@ -282,7 +282,7 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '^2.0.0',
               },
             ],
@@ -363,7 +363,10 @@ describe('CDVC', function () {
               versions: [
                 {
                   version: '^1.0.0',
-                  packages: ['', 'package1'],
+                  packages: [
+                    { pathRelative: '' },
+                    { pathRelative: 'package1' },
+                  ],
                 },
               ],
             },
@@ -374,15 +377,15 @@ describe('CDVC', function () {
               versions: [
                 {
                   version: '^1.0.0',
-                  packages: [''],
+                  packages: [{ pathRelative: '' }],
                 },
                 {
                   version: '^1.2.0',
-                  packages: [''],
+                  packages: [{ pathRelative: '' }],
                 },
                 {
                   version: '^2.0.0',
-                  packages: ['package1'],
+                  packages: [{ pathRelative: 'package1' }],
                 },
               ],
             },
@@ -408,7 +411,7 @@ describe('CDVC', function () {
             name: 'bar',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '^1.0.0',
               },
             ],
@@ -419,7 +422,7 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '^2.0.0',
               },
             ],
@@ -500,7 +503,10 @@ describe('CDVC', function () {
               versions: [
                 {
                   version: '^1.0.0',
-                  packages: ['', 'package1'],
+                  packages: [
+                    { pathRelative: '' },
+                    { pathRelative: 'package1' },
+                  ],
                 },
               ],
             },
@@ -511,15 +517,15 @@ describe('CDVC', function () {
               versions: [
                 {
                   version: '^1.0.0',
-                  packages: [''],
+                  packages: [{ pathRelative: '' }],
                 },
                 {
                   version: '^1.2.0',
-                  packages: [''],
+                  packages: [{ pathRelative: '' }],
                 },
                 {
                   version: '^2.0.0',
-                  packages: ['package1'],
+                  packages: [{ pathRelative: 'package1' }],
                 },
               ],
             },
@@ -545,7 +551,7 @@ describe('CDVC', function () {
             name: 'bar',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '^1.0.0',
               },
             ],
@@ -556,7 +562,7 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [''],
+                packages: [{ pathRelative: '' }],
                 version: '^2.0.0',
               },
             ],
@@ -599,8 +605,8 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                path.join('@scope1', 'package1'),
-                path.join('@scope1', 'package2'),
+                { pathRelative: path.join('@scope1', 'package1') },
+                { pathRelative: path.join('@scope1', 'package2') },
               ],
               version: '^4.5.6',
             },
@@ -612,11 +618,11 @@ describe('CDVC', function () {
           name: 'baz',
           versions: [
             {
-              packages: [path.join('@scope1', 'package1')],
+              packages: [{ pathRelative: path.join('@scope1', 'package1') }],
               version: '^7.8.9',
             },
             {
-              packages: [path.join('@scope1', 'package2')],
+              packages: [{ pathRelative: path.join('@scope1', 'package2') }],
               version: '^8.0.0',
             },
           ],
@@ -669,11 +675,11 @@ describe('CDVC', function () {
           name: 'foo',
           versions: [
             {
-              packages: ['package1'],
+              packages: [{ pathRelative: 'package1' }],
               version: '^1.0.0',
             },
             {
-              packages: ['package2'],
+              packages: [{ pathRelative: 'package2' }],
               version: '*',
             },
           ],
@@ -745,11 +751,11 @@ describe('CDVC', function () {
           name: 'foo',
           versions: [
             {
-              packages: ['package1'],
+              packages: [{ pathRelative: 'package1' }],
               version: '^1.0.0',
             },
             {
-              packages: ['package2'],
+              packages: [{ pathRelative: 'package2' }],
               version: '1.5.0',
             },
           ],
@@ -817,11 +823,11 @@ describe('CDVC', function () {
           name: 'foo',
           versions: [
             {
-              packages: ['package1'],
+              packages: [{ pathRelative: 'package1' }],
               version: '^1.0.0',
             },
             {
-              packages: ['package2'],
+              packages: [{ pathRelative: 'package2' }],
               version: '1.5.0',
             },
           ],


### PR DESCRIPTION
Fixes #600.