### PR TITLE
Fix default for `optionalDependencies` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These options are available on the CLI and as parameters to the [Node API](#node
 
 | Name | Description |
 | :-- | :-- |
-| `--dep-type` | Type of dependency to check (`dependencies`, `devDependencies`, `optionalDependencies` (optional), `peerDependencies` (optional), `resolutions`) (default: `dependencies`, `devDependencies`, `resolutions`) (option can be repeated). |
+| `--dep-type` | Type of dependency to check (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies` (optional), `resolutions`) (default: `dependencies`, `devDependencies`, `optionalDependencies`, `resolutions`) (option can be repeated). |
 | `--fix` | Whether to autofix inconsistencies (using latest version present). |
 | `--ignore-dep` | Dependency to ignore mismatches for (option can be repeated). |
 | `--ignore-dep-pattern` | RegExp of dependency names to ignore mismatches for (option can be repeated). |


### PR DESCRIPTION
Follow-up to #608.