### PR TITLE
Allow `--dep-type` option to be specified with CSV

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -19,9 +19,26 @@ function getCurrentPackageVersion(): string {
   return packageJson.version;
 }
 
-// Used for collecting repeated CLI options into an array.
-function collect(value: string, previous: readonly string[]) {
+/**
+ * Used for collecting repeated CLI options into an array.
+ * Example: --foo bar --foo baz => ['bar', 'baz']
+ */
+function collect(
+  value: string,
+  previous: readonly string[]
+): readonly string[] {
   return [...previous, value];
+}
+
+/**
+ * Used for collecting both repeated and CSV CLI options into an array.
+ * Example: --foo bar,baz,buz --foo biz => ['bar', 'baz', 'buz', 'biz']
+ * */
+function collectCSV(
+  value: string,
+  previous: readonly string[]
+): readonly string[] {
+  return [...previous, ...value.split(',')];
 }
 
 // Setup CLI.
@@ -41,7 +58,7 @@ export function run() {
       ).join(', ')}) (default: ${DEFAULT_DEP_TYPES.join(
         ', '
       )}) (option can be repeated)`,
-      collect,
+      collectCSV,
       []
     )
     .option(


### PR DESCRIPTION
Before, to specify multiple values, you would have to repeat the option:

```sh
--dep-type dependencies --dep-type devDependencies
```

After, you can also use CSV:

```sh
--dep-type dependencies,devDependencies
```

This function is also used here: https://github.com/bmish/eslint-doc-generator/blob/e9594090e38a4a2e71e56ba0588a5c223435cd5f/lib/cli.ts#L32

Unfortunately, we don't have tests for the CLI yet.