### PR TITLE
Drop Node 16 and 20 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
* Drop Node 16.x because it's no longer supported
* Drop Node 20.x temporarily because CI fails with it (will be added back eventually)