### PR TITLE
Test under Node 22 and Node 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 23.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/nodejs/Release

Verifies our compatibility with the current/latest Node versions.