### PR TITLE
Drop support for Node v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 22.x, 23.x, 24.x]
 
     steps:
     - uses: actions/checkout@v5

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "typescript-eslint": "^8.0.0"
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^23.0.0 || >=24.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Removing Node v18 as it is no longer supported.