### PR TITLE
refactor: Loop over dependency types in fixVersionsMismatching

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -335,7 +335,6 @@ function writeDependencyVersion(
   );
 }
 
-// eslint-disable-next-line complexity
 export function fixVersionsMismatching(
   packages: readonly Package[],
   mismatchingVersions: readonly DependencyAndVersions[],
@@ -388,97 +387,27 @@ export function fixVersionsMismatching(
     // Update the dependency version in each package.json.
     let isFixed = false;
     for (const package_ of packages) {
-      if (
-        package_.packageJson.devDependencies &&
-        package_.packageJson.devDependencies[mismatchingVersion.dependency] &&
-        package_.packageJson.devDependencies[mismatchingVersion.dependency] !==
-          fixedVersion
-      ) {
-        if (!dryrun) {
-          writeDependencyVersion(
-            package_.pathPackageJson,
-            package_.packageJsonEndsInNewline,
-            DEPENDENCY_TYPE.devDependencies,
-            mismatchingVersion.dependency,
-            fixedVersion,
-          );
+      for (const type of [
+        DEPENDENCY_TYPE.devDependencies,
+        DEPENDENCY_TYPE.dependencies,
+        DEPENDENCY_TYPE.optionalDependencies,
+        DEPENDENCY_TYPE.peerDependencies,
+        DEPENDENCY_TYPE.resolutions,
+      ]) {
+        const currentVersion =
+          package_.packageJson[type]?.[mismatchingVersion.dependency];
+        if (currentVersion && currentVersion !== fixedVersion) {
+          if (!dryrun) {
+            writeDependencyVersion(
+              package_.pathPackageJson,
+              package_.packageJsonEndsInNewline,
+              type,
+              mismatchingVersion.dependency,
+              fixedVersion,
+            );
+          }
+          isFixed = true;
         }
-        isFixed = true;
-      }
-
-      if (
-        package_.packageJson.dependencies &&
-        package_.packageJson.dependencies[mismatchingVersion.dependency] &&
-        package_.packageJson.dependencies[mismatchingVersion.dependency] !==
-          fixedVersion
-      ) {
-        if (!dryrun) {
-          writeDependencyVersion(
-            package_.pathPackageJson,
-            package_.packageJsonEndsInNewline,
-            DEPENDENCY_TYPE.dependencies,
-            mismatchingVersion.dependency,
-            fixedVersion,
-          );
-        }
-        isFixed = true;
-      }
-
-      if (
-        package_.packageJson.optionalDependencies &&
-        package_.packageJson.optionalDependencies[
-          mismatchingVersion.dependency
-        ] &&
-        package_.packageJson.optionalDependencies[
-          mismatchingVersion.dependency
-        ] !== fixedVersion
-      ) {
-        if (!dryrun) {
-          writeDependencyVersion(
-            package_.pathPackageJson,
-            package_.packageJsonEndsInNewline,
-            DEPENDENCY_TYPE.optionalDependencies,
-            mismatchingVersion.dependency,
-            fixedVersion,
-          );
-        }
-        isFixed = true;
-      }
-
-      if (
-        package_.packageJson.peerDependencies &&
-        package_.packageJson.peerDependencies[mismatchingVersion.dependency] &&
-        package_.packageJson.peerDependencies[mismatchingVersion.dependency] !==
-          fixedVersion
-      ) {
-        if (!dryrun) {
-          writeDependencyVersion(
-            package_.pathPackageJson,
-            package_.packageJsonEndsInNewline,
-            DEPENDENCY_TYPE.peerDependencies,
-            mismatchingVersion.dependency,
-            fixedVersion,
-          );
-        }
-        isFixed = true;
-      }
-
-      if (
-        package_.packageJson.resolutions &&
-        package_.packageJson.resolutions[mismatchingVersion.dependency] &&
-        package_.packageJson.resolutions[mismatchingVersion.dependency] !==
-          fixedVersion
-      ) {
-        if (!dryrun) {
-          writeDependencyVersion(
-            package_.pathPackageJson,
-            package_.packageJsonEndsInNewline,
-            DEPENDENCY_TYPE.resolutions,
-            mismatchingVersion.dependency,
-            fixedVersion,
-          );
-        }
-        isFixed = true;
       }
     }
 


### PR DESCRIPTION
## Summary

The inner write loop in `fixVersionsMismatching` repeated the same `if (packageJson[X] && packageJson[X][dep] && packageJson[X][dep] !== fixedVersion) { writeDependencyVersion(...) }` block five times — once per dependency type. This collapses them into a loop over the dependency types. ~95 lines → ~20.

This was the most error-prone spot in the codebase: adding a new dependency type previously meant editing two separate unrolled blocks (this one and `recordDependencyVersionsForPackageJson`) and it was easy to miss one.

## Notes

- Behavior-preserving; the per-type iteration order (dev, deps, optional, peer, resolutions) is unchanged.
- Removes the `// eslint-disable-next-line complexity` suppression.

## Testing

- `npm run lint:types` (tsgo) ✅
- `npm run lint:js` (eslint) ✅
- `npx vitest run` — 79/79 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)