### PR TITLE
refactor: Simplify map handling in recordDependencyVersion

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -174,16 +174,12 @@ function recordDependencyVersion(
   package_: Package,
   isLocalPackageVersion = false,
 ) {
-  if (!dependenciesToVersionsSeen.has(dependency)) {
-    dependenciesToVersionsSeen.set(dependency, []);
+  let list = dependenciesToVersionsSeen.get(dependency);
+  if (!list) {
+    list = [];
+    dependenciesToVersionsSeen.set(dependency, list);
   }
-  const list = dependenciesToVersionsSeen.get(dependency);
-  /* v8 ignore start */
-  if (list) {
-    // `list` should always exist at this point, this if statement is just to please TypeScript.
-    list.push({ package: package_, version, isLocalPackageVersion });
-  }
-  /* v8 ignore stop */
+  list.push({ package: package_, version, isLocalPackageVersion });
 }
 
 export function calculateDependenciesAndVersions(


### PR DESCRIPTION
## Summary

`recordDependencyVersion` used a `has`/`set`/`get` sequence and then guarded the result with `if (list)` — a check that can never be false but that TypeScript requires, hence the `/* v8 ignore */` block wrapping it (untestable dead branch).

Switching to the standard get-or-create pattern makes `list` a non-nullable local, so the guard and the coverage-ignore both disappear:

```ts
let list = dependenciesToVersionsSeen.get(dependency);
if (!list) {
  list = [];
  dependenciesToVersionsSeen.set(dependency, list);
}
list.push({ package: package_, version, isLocalPackageVersion });
```

## Testing

- `npm run lint:types` (tsgo) ✅
- `npm run lint:js` (eslint) ✅
- `npx vitest run --coverage` — 79/79, coverage still 100% ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)