### PR TITLE
chore: Remove stale jest.config.ts exclude from tsconfig.build.json

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "test/**/*.ts",
-    "jest.config.ts"
-  ]
+  "exclude": ["test/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

`tsconfig.build.json` excludes `jest.config.ts`, but this project uses Vitest and has no `jest.config.ts` file — a leftover from the Jest→Vitest migration. Removed the dead entry.

## Testing

- `npm run build` ✅ (dist still emits correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)