### PR TITLE
refactor: Name the VersionSeen entry type

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -12,9 +12,16 @@ import {
 import { DEPENDENCY_TYPE } from './types.js';
 import type { DependencyType } from './types.js';
 
+/** A version of a dependency seen in a particular package. */
+type VersionSeen = {
+  package: Package;
+  version: string;
+  isLocalPackageVersion: boolean;
+};
+
 type DependenciesToVersionsSeen = Map<
   string,
-  { package: Package; version: string; isLocalPackageVersion: boolean }[] // Array can't be readonly since we are adding to it.
+  VersionSeen[] // Array can't be readonly since we are adding to it.
 >;
 
 /** A dependency, the versions present of it, and the packages each of those versions are seen in. */
@@ -48,7 +55,7 @@ export function calculateVersionsForEachDependency(
 ): DependenciesToVersionsSeen {
   const dependenciesToVersionsSeen: DependenciesToVersionsSeen = new Map<
     string,
-    { package: Package; version: string; isLocalPackageVersion: boolean }[]
+    VersionSeen[]
   >();
   for (const package_ of packages) {
     recordDependencyVersionsForPackageJson(
@@ -239,11 +246,7 @@ export function calculateDependenciesAndVersions(
 
 function versionsObjectsWithSortedPackages(
   versions: readonly string[],
-  versionObjects: readonly {
-    package: Package;
-    version: string;
-    isLocalPackageVersion: boolean;
-  }[],
+  versionObjects: readonly VersionSeen[],
 ) {
   return versions.map((version) => {
     const matchingVersionObjects = versionObjects.filter(


### PR DESCRIPTION
## Summary

The inline shape `{ package: Package; version: string; isLocalPackageVersion: boolean }` was repeated three times in `dependency-versions.ts` (the `DependenciesToVersionsSeen` map value, the `new Map<...>()` generic, and the `versionsObjectsWithSortedPackages` parameter). Extracted it into a single named `VersionSeen` type.

## Testing

- `npm run lint:types` (tsgo) ✅
- `npm run lint:js` (eslint) ✅
- `npx vitest run` — 79/79 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)