### PR TITLE
refactor: Use optional chaining for options.depType in check.ts

### DIFF
--- a/lib/check.ts
+++ b/lib/check.ts
@@ -31,9 +31,7 @@ export function check(
   dependencies: Dependencies;
 } {
   if (
-    options &&
-    options.depType &&
-    options.depType.some((dt) => !Object.keys(DEPENDENCY_TYPE).includes(dt))
+    options?.depType?.some((dt) => !Object.keys(DEPENDENCY_TYPE).includes(dt))
   ) {
     throw new Error(
       `Invalid depType provided. Choices are: ${Object.keys(
@@ -54,7 +52,7 @@ export function check(
 
     // Fallback to default if no depType(s) provided.
     depType:
-      options && options.depType && options.depType.length > 0
+      options?.depType && options.depType.length > 0
         ? options.depType
         : DEFAULT_DEP_TYPES,
   };


### PR DESCRIPTION
## Summary

Minor readability cleanup in `check()`: replace the `options && options.depType && ...` guards with optional chaining (`options?.depType?.some(...)` and `options?.depType && ...`).

## Testing

- `npm run lint:types` (tsgo) ✅
- `npm run lint:js` (eslint) ✅
- `npx vitest run --coverage` — 79/79, coverage still 100% ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)