### PR TITLE
refactor: Replace edit-json-file with native JSON writer

### DIFF
--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -1,7 +1,6 @@
-import { readFileSync, writeFileSync } from 'node:fs';
 import semver from 'semver';
-import type { PackageJson } from 'type-fest';
 import { DEFAULT_DEP_TYPES } from './defaults.js';
+import { editJsonFile } from './edit-json-file.js';
 import { Package } from './package.js';
 import {
   compareVersionRanges,
@@ -237,12 +236,6 @@ export function filterOutIgnoredDependencies(
   return mismatchingVersions;
 }
 
-/** Detect JSON indent from file contents. Returns spaces/tabs string, or 0 for compact JSON. */
-export function detectJsonIndent(contents: string): string | number {
-  const match = /\n([ \t]+)"/.exec(contents);
-  return match?.[1] ?? 0;
-}
-
 function writeDependencyVersion(
   packageJsonPath: string,
   packageJsonEndsInNewline: boolean,
@@ -250,23 +243,9 @@ function writeDependencyVersion(
   dependencyName: string,
   newVersion: string,
 ) {
-  const contents = readFileSync(packageJsonPath, 'utf8');
-  const packageJson = JSON.parse(contents) as PackageJson;
-  // Caller only invokes this when the dependency already exists under `type`.
-  packageJson[type] = {
-    ...packageJson[type],
-    [dependencyName]: newVersion,
-  };
-
-  let output = JSON.stringify(
-    packageJson,
-    undefined,
-    detectJsonIndent(contents),
-  );
-  if (packageJsonEndsInNewline) {
-    output += '\n';
-  }
-  writeFileSync(packageJsonPath, output);
+  editJsonFile(packageJsonPath, {
+    endsWithNewline: packageJsonEndsInNewline,
+  }).set([type, dependencyName], newVersion);
 }
 
 export function fixVersionsMismatching(

--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -1,5 +1,6 @@
-import editJsonFile from 'edit-json-file';
+import { readFileSync, writeFileSync } from 'node:fs';
 import semver from 'semver';
+import type { PackageJson } from 'type-fest';
 import { DEFAULT_DEP_TYPES } from './defaults.js';
 import { Package } from './package.js';
 import {
@@ -236,6 +237,12 @@ export function filterOutIgnoredDependencies(
   return mismatchingVersions;
 }
 
+/** Detect JSON indent from file contents. Returns spaces/tabs string, or 0 for compact JSON. */
+export function detectJsonIndent(contents: string): string | number {
+  const match = /\n([ \t]+)"/.exec(contents);
+  return match?.[1] ?? 0;
+}
+
 function writeDependencyVersion(
   packageJsonPath: string,
   packageJsonEndsInNewline: boolean,
@@ -243,19 +250,23 @@ function writeDependencyVersion(
   dependencyName: string,
   newVersion: string,
 ) {
-  const packageJsonEditor = editJsonFile(packageJsonPath, {
-    autosave: true,
-    stringify_eol: packageJsonEndsInNewline, // If a newline at end of file exists, keep it.
-  });
+  const contents = readFileSync(packageJsonPath, 'utf8');
+  const packageJson = JSON.parse(contents) as PackageJson;
+  // Caller only invokes this when the dependency already exists under `type`.
+  packageJson[type] = {
+    ...packageJson[type],
+    [dependencyName]: newVersion,
+  };
 
-  packageJsonEditor.set(
-    `${type}.${dependencyName.replaceAll(
-      '.', // Escape dots to avoid creating unwanted nested properties.
-      String.raw`\.`,
-    )}`,
-    newVersion,
-    { preservePaths: false }, // Disable `preservePaths` so that nested dependency names (i.e. @types/jest) won't prevent the intentional dot in the path we provide from working.
+  let output = JSON.stringify(
+    packageJson,
+    undefined,
+    detectJsonIndent(contents),
   );
+  if (packageJsonEndsInNewline) {
+    output += '\n';
+  }
+  writeFileSync(packageJsonPath, output);
 }
 
 export function fixVersionsMismatching(

--- a/lib/edit-json-file.ts
+++ b/lib/edit-json-file.ts
@@ -1,0 +1,65 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/** Detect JSON indent from file contents. Returns spaces/tabs string, or 0 for compact JSON. */
+export function detectJsonIndent(contents: string): string | number {
+  const match = /\n([ \t]+)"/.exec(contents);
+  return match?.[1] ?? 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+type EditJsonFileOptions = {
+  /** Keep a trailing newline when the original file had one. Defaults to detecting from the file. */
+  endsWithNewline?: boolean;
+};
+
+/**
+ * Minimal local replacement for the `edit-json-file` package.
+ * Preserves detected indent and trailing newline.
+ *
+ * @example
+ * ```ts
+ * editJsonFile('package.json').set(['dependencies', '@types/node'], '^22.0.0');
+ * ```
+ */
+export function editJsonFile(
+  path: string,
+  options: EditJsonFileOptions = {},
+): {
+  set: (keys: readonly string[], value: unknown) => void;
+} {
+  return {
+    set(keys: readonly string[], value: unknown) {
+      const lastKey = keys.at(-1);
+      if (lastKey === undefined) {
+        throw new Error('editJsonFile().set() requires at least one key.');
+      }
+
+      const contents = readFileSync(path, 'utf8');
+      const data: unknown = JSON.parse(contents);
+      if (!isPlainObject(data)) {
+        throw new TypeError(`Expected ${path} to contain a JSON object.`);
+      }
+
+      let cursor = data;
+      for (const key of keys.slice(0, -1)) {
+        const next = cursor[key];
+        if (!isPlainObject(next)) {
+          cursor[key] = {};
+        }
+        cursor = cursor[key] as Record<string, unknown>;
+      }
+      cursor[lastKey] = value;
+
+      const endsWithNewline =
+        options.endsWithNewline ?? contents.endsWith('\n');
+      let output = JSON.stringify(data, undefined, detectJsonIndent(contents));
+      if (endsWithNewline) {
+        output += '\n';
+      }
+      writeFileSync(path, output);
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "chalk": "^5.2.0",
         "commander": "^14.0.1",
-        "edit-json-file": "^1.7.0",
         "globby": "^16.1.0",
         "js-yaml": "^4.1.0",
         "semver": "^7.5.1",
@@ -23,7 +22,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
-        "@types/edit-json-file": "^1.7.0",
         "@types/js-yaml": "^4.0.5",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^25.0.0",
@@ -1215,17 +1213,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/edit-json-file": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@types/edit-json-file/-/edit-json-file-1.7.4.tgz",
-      "integrity": "sha512-lltApjZ/bhirCs4UweEgft9iPG8LvIWHSoL6YwXeGjmL7lbs2vWjn50IdAKlyXcbulWiSZJyfrcb+FS2803nGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/set-value": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1306,13 +1293,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/set-value": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/set-value/-/set-value-4.0.3.tgz",
-      "integrity": "sha512-tSuUcLl6kMzI+l0gG7FZ04xbIcynxNIYgWFj91LPAvRcn7W3L1EveXNdVjqFDgAZPjY1qCOsm8Sb1C70SxAPHw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2820,19 +2800,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/edit-json-file": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/edit-json-file/-/edit-json-file-1.8.1.tgz",
-      "integrity": "sha512-x8L381+GwqxQejPipwrUZIyAg5gDQ9tLVwiETOspgXiaQztLsrOm7luBW5+Pe31aNezuzDY79YyzF+7viCRPXA==",
-      "license": "MIT",
-      "dependencies": {
-        "find-value": "^1.0.12",
-        "iterate-object": "^1.3.4",
-        "r-json": "^1.2.10",
-        "set-value": "^4.1.0",
-        "w-json": "^1.3.10"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -3744,12 +3711,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/find-value": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/find-value/-/find-value-1.0.13.tgz",
-      "integrity": "sha512-epNL4mnl3HUYrwVQtZ8s0nxkE4ogAoSqO1V1fa670Ww1fXp8Yr74zNS9Aib/vLNf0rq0AF/4mboo7ev5XkikXQ==",
-      "license": "MIT"
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -4623,27 +4584,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-primitive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
-      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4816,15 +4756,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4878,12 +4809,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/iterate-object": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.5.tgz",
-      "integrity": "sha512-eL23u8oFooYTq6TtJKjp2RYjZnCkUYQvC0T/6fJfWykXJ3quvdDdzKZ3CEjy8b3JGOvLTjDYMEMIp5243R906A==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6819,21 +6744,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/r-json": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/r-json/-/r-json-1.3.1.tgz",
-      "integrity": "sha512-5nhRFfjVMQdrwKUfUlRpDUCocdKtjSnYZ1R/86mpZDV3MfsZ3dYYNjSGuMX+mPBvFvQBhdzxSqxkuLPLv4uFGg==",
-      "license": "MIT",
-      "dependencies": {
-        "w-json": "1.3.10"
-      }
-    },
-    "node_modules/r-json/node_modules/w-json": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/w-json/-/w-json-1.3.10.tgz",
-      "integrity": "sha512-XadVyw0xE+oZ5FGApXsdswv96rOhStzKqL53uSe5UaTadABGkWIg1+DTx8kiZ/VqTZTBneoL0l65RcPe4W3ecw==",
-      "license": "MIT"
-    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -7391,24 +7301,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-value": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
-      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
-      "funding": [
-        "https://github.com/sponsors/jonschlinkert",
-        "https://paypal.me/jonathanschlinkert",
-        "https://jonschlinkert.dev/sponsor"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "is-primitive": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=11.0"
       }
     },
     "node_modules/shebang-command": {
@@ -8645,12 +8537,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/w-json": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/w-json/-/w-json-1.3.11.tgz",
-      "integrity": "sha512-Xa8vTinB5XBIYZlcN8YyHpE625pBU6k+lvCetTQM+FKxRtLJxAY9zUVZbRqCqkMeEGbQpKvGUzwh4wZKGem+ag==",
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "chalk": "^5.2.0",
     "commander": "^14.0.1",
-    "edit-json-file": "^1.7.0",
     "globby": "^16.1.0",
     "js-yaml": "^4.1.0",
     "semver": "^7.5.1",
@@ -57,7 +56,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
-    "@types/edit-json-file": "^1.7.0",
     "@types/js-yaml": "^4.0.5",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^25.0.0",

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -1,6 +1,7 @@
 import {
   calculateVersionsForEachDependency,
   calculateDependenciesAndVersions,
+  detectJsonIndent,
   filterOutIgnoredDependencies,
   fixVersionsMismatching,
 } from '../../lib/dependency-versions.js';
@@ -390,6 +391,20 @@ describe('Utils | dependency-versions', function () {
     });
   });
 
+  describe('#detectJsonIndent', function () {
+    it('detects two-space indent', function () {
+      expect(detectJsonIndent('{\n  "name": "foo"\n}\n')).toBe('  ');
+    });
+
+    it('detects tab indent', function () {
+      expect(detectJsonIndent('{\n\t"name": "foo"\n}\n')).toBe('\t');
+    });
+
+    it('returns 0 for compact JSON', function () {
+      expect(detectJsonIndent('{"name":"foo"}')).toBe(0);
+    });
+  });
+
   describe('#fixVersionsMismatching', function () {
     describe('inconsistent dependency versions', function () {
       beforeEach(function () {
@@ -514,6 +529,10 @@ describe('Utils | dependency-versions', function () {
           packageJson2.devDependencies &&
             packageJson2.devDependencies['@types/one'],
         ).toStrictEqual('1.0.1');
+
+        // Preserves trailing newline only when the original file had one.
+        expect(packageJson1Contents.endsWith('\n')).toBe(false);
+        expect(packageJson2Contents.endsWith('\n')).toBe(true);
 
         // Check return value.
         expect(notFixable).toStrictEqual([
@@ -861,6 +880,98 @@ describe('Utils | dependency-versions', function () {
             ],
           },
         ]);
+      });
+    });
+
+    describe('preserves formatting', function () {
+      afterEach(function () {
+        mockFs.restore();
+      });
+
+      it('preserves two-space indent and trailing newline', function () {
+        mockFs({
+          'package.json': JSON.stringify({ workspaces: ['*'] }, undefined, 2),
+          package1: {
+            'package.json': `${JSON.stringify(
+              {
+                name: 'package1',
+                dependencies: { foo: '^1.0.0' },
+              },
+              undefined,
+              2,
+            )}\n`,
+          },
+          package2: {
+            'package.json': `${JSON.stringify(
+              {
+                name: 'package2',
+                dependencies: { foo: '^2.0.0' },
+              },
+              undefined,
+              2,
+            )}\n`,
+          },
+        });
+
+        const packages = getPackagesHelper('.');
+        fixVersionsMismatching(
+          packages,
+          calculateDependenciesAndVersions(
+            calculateVersionsForEachDependency(packages),
+          ),
+        );
+
+        const packageJson1Contents = readFileSync(
+          'package1/package.json',
+          'utf8',
+        );
+        expect(packageJson1Contents).toBe(
+          `${JSON.stringify(
+            {
+              name: 'package1',
+              dependencies: { foo: '^2.0.0' },
+            },
+            undefined,
+            2,
+          )}\n`,
+        );
+      });
+
+      it('preserves compact JSON without trailing newline', function () {
+        mockFs({
+          'package.json': JSON.stringify({ workspaces: ['*'] }),
+          package1: {
+            'package.json': JSON.stringify({
+              name: 'package1',
+              dependencies: { foo: '^1.0.0' },
+            }),
+          },
+          package2: {
+            'package.json': JSON.stringify({
+              name: 'package2',
+              dependencies: { foo: '^2.0.0' },
+            }),
+          },
+        });
+
+        const packages = getPackagesHelper('.');
+        fixVersionsMismatching(
+          packages,
+          calculateDependenciesAndVersions(
+            calculateVersionsForEachDependency(packages),
+          ),
+        );
+
+        const packageJson1Contents = readFileSync(
+          'package1/package.json',
+          'utf8',
+        );
+        expect(packageJson1Contents).toBe(
+          JSON.stringify({
+            name: 'package1',
+            dependencies: { foo: '^2.0.0' },
+          }),
+        );
       });
     });
 

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -1,7 +1,6 @@
 import {
   calculateVersionsForEachDependency,
   calculateDependenciesAndVersions,
-  detectJsonIndent,
   filterOutIgnoredDependencies,
   fixVersionsMismatching,
 } from '../../lib/dependency-versions.js';
@@ -388,20 +387,6 @@ describe('Utils | dependency-versions', function () {
       expect(
         filterOutIgnoredDependencies(dependencyVersions, [], []).length,
       ).toStrictEqual(3);
-    });
-  });
-
-  describe('#detectJsonIndent', function () {
-    it('detects two-space indent', function () {
-      expect(detectJsonIndent('{\n  "name": "foo"\n}\n')).toBe('  ');
-    });
-
-    it('detects tab indent', function () {
-      expect(detectJsonIndent('{\n\t"name": "foo"\n}\n')).toBe('\t');
-    });
-
-    it('returns 0 for compact JSON', function () {
-      expect(detectJsonIndent('{"name":"foo"}')).toBe(0);
     });
   });
 

--- a/test/lib/edit-json-file-test.ts
+++ b/test/lib/edit-json-file-test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+import mockFs from 'mock-fs';
+import { detectJsonIndent, editJsonFile } from '../../lib/edit-json-file.js';
+
+describe('Utils | edit-json-file', function () {
+  describe('#detectJsonIndent', function () {
+    it('detects two-space indent', function () {
+      expect(detectJsonIndent('{\n  "name": "foo"\n}\n')).toBe('  ');
+    });
+
+    it('detects tab indent', function () {
+      expect(detectJsonIndent('{\n\t"name": "foo"\n}\n')).toBe('\t');
+    });
+
+    it('returns 0 for compact JSON', function () {
+      expect(detectJsonIndent('{"name":"foo"}')).toBe(0);
+    });
+  });
+
+  describe('#editJsonFile', function () {
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('sets a nested key and preserves two-space indent and trailing newline', function () {
+      mockFs({
+        'package.json': `${JSON.stringify(
+          {
+            dependencies: { foo: '^1.0.0' },
+          },
+          undefined,
+          2,
+        )}\n`,
+      });
+
+      editJsonFile('package.json').set(['dependencies', 'foo'], '^2.0.0');
+
+      expect(readFileSync('package.json', 'utf8')).toBe(
+        `${JSON.stringify(
+          {
+            dependencies: { foo: '^2.0.0' },
+          },
+          undefined,
+          2,
+        )}\n`,
+      );
+    });
+
+    it('sets dotted / scoped dependency names without treating dots as path separators', function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          devDependencies: { '@types/node': '1.0.0', 'a.b.c': '1.0.0' },
+        }),
+      });
+
+      editJsonFile('package.json', { endsWithNewline: false }).set(
+        ['devDependencies', '@types/node'],
+        '2.0.0',
+      );
+      editJsonFile('package.json', { endsWithNewline: false }).set(
+        ['devDependencies', 'a.b.c'],
+        '2.0.0',
+      );
+
+      expect(JSON.parse(readFileSync('package.json', 'utf8'))).toStrictEqual({
+        devDependencies: { '@types/node': '2.0.0', 'a.b.c': '2.0.0' },
+      });
+    });
+
+    it('creates intermediate objects when missing', function () {
+      mockFs({
+        'package.json': '{}',
+      });
+
+      editJsonFile('package.json', { endsWithNewline: false }).set(
+        ['dependencies', 'foo'],
+        '^1.0.0',
+      );
+
+      expect(readFileSync('package.json', 'utf8')).toBe(
+        JSON.stringify({ dependencies: { foo: '^1.0.0' } }),
+      );
+    });
+
+    it('throws when no keys are provided', function () {
+      mockFs({
+        'package.json': '{}',
+      });
+
+      expect(() => {
+        editJsonFile('package.json').set([], 'value');
+      }).toThrow('editJsonFile().set() requires at least one key.');
+    });
+
+    it('throws when the file is not a JSON object', function () {
+      mockFs({
+        'package.json': '[]',
+      });
+
+      expect(() => {
+        editJsonFile('package.json').set(['foo'], 'bar');
+      }).toThrowErrorMatchingInlineSnapshot(
+        '[TypeError: Expected package.json to contain a JSON object.]',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`--fix` no longer depends on **edit-json-file**. Writes use a small native read → mutate → `JSON.stringify` path that:

- Preserves detected indent (spaces, tabs, or compact)
- Preserves trailing newlines
- Handles scoped / dotted dependency names (`@types/one`, `a.b.c`) without path-escaping hacks

Removes `edit-json-file` and `@types/edit-json-file` (12 transitive packages).

## Test plan

- [x] `npm test` — 84 tests, 100% lib coverage
- [x] `npm run lint:js` / `lint:types`
- [x] New tests for indent detection + formatting preservation on `--fix`

Made with [Cursor](https://cursor.com)