### PR TITLE
chore: Move type-fest to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "globby": "^16.1.0",
         "js-yaml": "^4.1.0",
         "semver": "^7.5.1",
-        "table": "^6.8.1",
-        "type-fest": "^5.3.1"
+        "table": "^6.8.1"
       },
       "bin": {
         "check-dependency-version-consistency": "dist/bin/check-dependency-version-consistency.js"
@@ -43,6 +42,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.7.4",
         "sort-package-json": "^3.6.0",
+        "type-fest": "^5.3.1",
         "typescript": "^5.0.4",
         "typescript-eslint": "^8.51.0",
         "vitest": "^4.0.0"
@@ -7994,6 +7994,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -8215,6 +8216,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.3.1.tgz",
       "integrity": "sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "globby": "^16.1.0",
     "js-yaml": "^4.1.0",
     "semver": "^7.5.1",
-    "table": "^6.8.1",
-    "type-fest": "^5.3.1"
+    "table": "^6.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
@@ -77,6 +76,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.7.4",
     "sort-package-json": "^3.6.0",
+    "type-fest": "^5.3.1",
     "typescript": "^5.0.4",
     "typescript-eslint": "^8.51.0",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary

- Move **type-fest** from `dependencies` to `devDependencies` — it is only used via `import type { PackageJson }`, so it should not ship as a runtime dependency.

## Test plan

- [x] `npm test`
- [x] `npm run lint:types`

Made with [Cursor](https://cursor.com)