### PR TITLE
refactor: Replace chalk with node:util.styleText

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { table } from 'table';
 import {
   compareVersionRangesSafe,
@@ -27,7 +27,11 @@ export function dependenciesToMismatchSummary(
 
   const tables = mismatchingDependencyVersions
     .map((object) => {
-      const headers = [chalk.bold(object.dependency), 'Usages', 'Packages'];
+      const headers = [
+        styleText('bold', object.dependency),
+        'Usages',
+        'Packages',
+      ];
 
       const usageCounts = object.versions.map(
         (versionObject) => versionObject.packages.length,
@@ -51,10 +55,10 @@ export function dependenciesToMismatchSummary(
                 )} other${usageCount - 3 === 1 ? '' : 's'}`
               : packageNames.join(', ');
           return [
-            chalk.redBright(versionObject.version),
+            styleText('redBright', versionObject.version),
             // Bold the usage count if it's the latest, as long as it's not the only usage count present.
             usageCount === latestUsageCount && hasMultipleUsageCounts
-              ? chalk.bold(usageCount)
+              ? styleText('bold', String(usageCount))
               : usageCount,
             packageListSentence,
           ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.2.0",
         "commander": "^14.0.1",
         "edit-json-file": "^1.7.0",
         "globby": "^16.1.0",
@@ -2364,18 +2363,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/change-case": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "chalk": "^5.2.0",
     "commander": "^14.0.1",
     "edit-json-file": "^1.7.0",
     "globby": "^16.1.0",


### PR DESCRIPTION
## Summary

- Replace **chalk** with Node's built-in `util.styleText` for bold/redBright CLI output styling.
- Removes one runtime dependency; supported on all current engines (`^20.19.0 || ^22.13.1 || >=24`).

## Test plan

- [x] `npm test` (output snapshots unchanged under `NO_COLOR`)
- [x] `npm run lint:js` / `lint:types`

Made with [Cursor](https://cursor.com)