### PR TITLE
docs: Note why type-fest must stay in dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ const result = {
 
 See [`lib/cli.ts`](./lib/cli.ts) for an example of how to use it.
 
+## Maintenance notes
+
+* **`type-fest` must stay in `dependencies`**, not `devDependencies`. It is only imported as a type, but `PackageJson` is emitted into published `.d.ts` files and is reachable from the public `CDVC` API. Moving it breaks TypeScript consumers when `skipLibCheck` is false (see [#959](https://github.com/bmish/check-dependency-version-consistency/pull/959), [#985](https://github.com/bmish/check-dependency-version-consistency/pull/985)).
+
 ## Related
 
 * [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) — use this complementary tool to enforce that your dependency versions use consistent range types (i.e. [prefer-caret-version-dependencies](https://npmpackagejsonlint.org/docs/rules/dependencies/prefer-caret-version-dependencies), [prefer-caret-version-devDependencies](https://npmpackagejsonlint.org/docs/rules/dependencies/prefer-caret-version-devDependencies))

--- a/README.md
+++ b/README.md
@@ -176,10 +176,6 @@ const result = {
 
 See [`lib/cli.ts`](./lib/cli.ts) for an example of how to use it.
 
-## Maintenance notes
-
-* **`type-fest` must stay in `dependencies`**, not `devDependencies`. It is only imported as a type, but `PackageJson` is emitted into published `.d.ts` files and is reachable from the public `CDVC` API. Moving it breaks TypeScript consumers when `skipLibCheck` is false (see [#959](https://github.com/bmish/check-dependency-version-consistency/pull/959), [#985](https://github.com/bmish/check-dependency-version-consistency/pull/985)).
-
 ## Related
 
 * [npm-package-json-lint](https://github.com/tclindner/npm-package-json-lint) — use this complementary tool to enforce that your dependency versions use consistent range types (i.e. [prefer-caret-version-dependencies](https://npmpackagejsonlint.org/docs/rules/dependencies/prefer-caret-version-dependencies), [prefer-caret-version-devDependencies](https://npmpackagejsonlint.org/docs/rules/dependencies/prefer-caret-version-devDependencies))

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,7 +1,8 @@
 import { Command, Argument } from 'commander';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-// See note on the `type-fest` import in `package.ts`.
+// Keep in `dependencies` (not `devDependencies`): see note on the `type-fest`
+// import in `package.ts`.
 import type { PackageJson } from 'type-fest';
 import { fileURLToPath } from 'node:url';
 import { CDVC } from './cdvc.js';

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,14 +1,13 @@
 import { Command, Argument } from 'commander';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+// See note on the `type-fest` import in `package.ts`.
 import type { PackageJson } from 'type-fest';
 import { fileURLToPath } from 'node:url';
 import { CDVC } from './cdvc.js';
 import { DEPENDENCY_TYPE } from './types.js';
 import type { Options } from './types.js';
 import { DEFAULT_DEP_TYPES } from './defaults.js';
-
-// See note in `package.ts` — `type-fest` must remain a runtime dependency.
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,8 +1,7 @@
 import { Command, Argument } from 'commander';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-// Keep in `dependencies` (not `devDependencies`): see note on the `type-fest`
-// import in `package.ts`.
+// Keep in `dependencies` (not `devDependencies`): see note on the `type-fest` import in `package.ts`.
 import type { PackageJson } from 'type-fest';
 import { fileURLToPath } from 'node:url';
 import { CDVC } from './cdvc.js';

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -8,6 +8,8 @@ import { DEPENDENCY_TYPE } from './types.js';
 import type { Options } from './types.js';
 import { DEFAULT_DEP_TYPES } from './defaults.js';
 
+// See note in `package.ts` — `type-fest` must remain a runtime dependency.
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function getCurrentPackageVersion(): string {

--- a/lib/package.ts
+++ b/lib/package.ts
@@ -1,8 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
-// Keep in `dependencies` (not `devDependencies`): emitted into published `.d.ts`
-// reachable from the public `CDVC` API; moving it breaks consumers with
-// `skipLibCheck: false` (see #959, #985).
+// Keep in `dependencies` (not `devDependencies`): emitted into published `.d.ts` reachable from the public `CDVC` API; moving it breaks consumers with `skipLibCheck: false` (see #959, #985).
 import type { PackageJson } from 'type-fest';
 import { load } from 'js-yaml';
 

--- a/lib/package.ts
+++ b/lib/package.ts
@@ -1,12 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
+// Keep in `dependencies` (not `devDependencies`): emitted into published `.d.ts`
+// reachable from the public `CDVC` API; moving it breaks consumers with
+// `skipLibCheck: false` (see #959, #985).
 import type { PackageJson } from 'type-fest';
 import { load } from 'js-yaml';
-
-// Keep `type-fest` in `dependencies` (not `devDependencies`): `PackageJson` is
-// emitted into published `.d.ts` files and is reachable from the public `CDVC`
-// API type graph. Moving it breaks consumer typechecking when `skipLibCheck`
-// is false (see #959, #985).
 
 /*
  * Class to represent all of the information we need to know about a package in a workspace.

--- a/lib/package.ts
+++ b/lib/package.ts
@@ -3,6 +3,11 @@ import { join, relative } from 'node:path';
 import type { PackageJson } from 'type-fest';
 import { load } from 'js-yaml';
 
+// Keep `type-fest` in `dependencies` (not `devDependencies`): `PackageJson` is
+// emitted into published `.d.ts` files and is reachable from the public `CDVC`
+// API type graph. Moving it breaks consumer typechecking when `skipLibCheck`
+// is false (see #959, #985).
+
 /*
  * Class to represent all of the information we need to know about a package in a workspace.
  */


### PR DESCRIPTION
## Summary

- Add a short comment next to the `type-fest` imports explaining why it must stay in `dependencies` (published `.d.ts` / public `CDVC` type graph; see #959, #985).

## Test plan

- [x] `npm run lint:js` / `lint:types`