### PR TITLE
feat: Expose dependency type in Node API (#614)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,14 @@ const result = {
   name: 'eslint',
   versions: [
     {
-      packages: [{ pathRelative: 'packages/package1' }, { pathRelative: 'packages/package2' }],
+      packages: [
+        { pathRelative: 'packages/package1', type: 'dependencies' },
+        { pathRelative: 'packages/package2', type: 'devDependencies' },
+      ],
       version: '^7.0.0',
     },
     {
-      packages: [{ pathRelative: 'packages/package3' }],
+      packages: [{ pathRelative: 'packages/package3', type: 'dependencies' }],
       version: '^8.0.0',
     },
   ],
@@ -172,7 +175,7 @@ const result = {
 | `isFixable` | `true` if the mismatching versions of this dependency are autofixable. |
 | `isMismatching` | `true` if there are multiple versions of this dependency. |
 | `name` | The dependency's name. |
-| `versions` | A list of the versions present of this dependency and the packages each is found in, in the form of: `{ version: string, packages: { pathRelative: string }[] }`. |
+| `versions` | A list of the versions present of this dependency and the packages each is found in, in the form of: `{ version: string, packages: { pathRelative: string, type?: string }[] }`. `type` is the dependency type (`dependencies`, `devDependencies`, etc.) for that usage, and is omitted for the entry representing the local workspace package itself. |
 
 See [`lib/cli.ts`](./lib/cli.ts) for an example of how to use it.
 

--- a/lib/cdvc.ts
+++ b/lib/cdvc.ts
@@ -3,7 +3,7 @@ import {
   dependenciesToFixedSummary,
   dependenciesToMismatchSummary,
 } from './output.js';
-import type { Dependencies, Options } from './types.js';
+import type { Dependencies, DependencyType, Options } from './types.js';
 
 /** Relevant public data about a dependency. */
 type Dependency = {
@@ -12,7 +12,10 @@ type Dependency = {
   isMismatching: boolean;
   versions: readonly {
     version: string;
-    packages: readonly { pathRelative: string }[];
+    packages: readonly {
+      pathRelative: string;
+      type?: DependencyType;
+    }[];
   }[];
 };
 
@@ -64,7 +67,8 @@ export class CDVC {
       versions: dep.versions.map((version) => ({
         version: version.version,
         packages: version.packages.map((package_) => ({
-          pathRelative: package_.pathRelative,
+          pathRelative: package_.package.pathRelative,
+          ...(package_.type === undefined ? {} : { type: package_.type }),
         })),
       })),
     };

--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -17,6 +17,7 @@ type VersionSeen = {
   package: Package;
   version: string;
   isLocalPackageVersion: boolean;
+  type: DependencyType | undefined;
 };
 
 type DependenciesToVersionsSeen = Map<
@@ -29,7 +30,10 @@ type DependencyAndVersions = {
   dependency: string;
   readonly versions: {
     version: string;
-    packages: readonly Package[];
+    packages: readonly {
+      package: Package;
+      type: DependencyType | undefined;
+    }[];
   }[];
 };
 
@@ -79,6 +83,7 @@ function recordDependencyVersionsForPackageJson(
       package_.packageJson.version,
       package_,
       true,
+      undefined,
     );
   }
 
@@ -92,6 +97,8 @@ function recordDependencyVersionsForPackageJson(
           dependency,
           dependencyVersion,
           package_,
+          false,
+          type,
         );
       }
     }
@@ -104,13 +111,14 @@ function recordDependencyVersion(
   version: string,
   package_: Package,
   isLocalPackageVersion = false,
+  type?: DependencyType,
 ) {
   let list = dependenciesToVersionsSeen.get(dependency);
   if (!list) {
     list = [];
     dependenciesToVersionsSeen.set(dependency, list);
   }
-  list.push({ package: package_, version, isLocalPackageVersion });
+  list.push({ package: package_, version, isLocalPackageVersion, type });
 }
 
 export function calculateDependenciesAndVersions(
@@ -175,8 +183,11 @@ function versionsObjectsWithSortedPackages(
     return {
       version,
       packages: matchingVersionObjects
-        .map((object) => object.package)
-        .toSorted((a, b) => Package.comparator(a, b)),
+        .map((object) => ({
+          package: object.package,
+          type: object.type,
+        }))
+        .toSorted((a, b) => Package.comparator(a.package, b.package)),
     };
   });
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
 // Public Node API.
 
 export { CDVC } from './cdvc.js';
+export { DEPENDENCY_TYPE } from './types.js';
+export type { DependencyType } from './types.js';

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -46,7 +46,7 @@ export function dependenciesToMismatchSummary(
         .map((versionObject) => {
           const usageCount = versionObject.packages.length;
           const packageNames = versionObject.packages.map(
-            (package_) => package_.name,
+            (p) => p.package.name,
           );
           const packageListSentence =
             usageCount > 3

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,7 +8,10 @@ export type Dependencies = Record<
     isMismatching: boolean;
     versions: readonly {
       version: string;
-      packages: readonly Package[];
+      packages: readonly {
+        package: Package;
+        type: DependencyType | undefined;
+      }[];
     }[];
   }
 >;

--- a/test/lib/cdvc-test.ts
+++ b/test/lib/cdvc-test.ts
@@ -1,4 +1,5 @@
 import {
+  FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION,
   FIXTURE_PATH_INCONSISTENT_VERSIONS,
   FIXTURE_PATH_OPTIONAL_DEPENDENCIES,
   FIXTURE_PATH_PEER_DEPENDENCIES,
@@ -29,10 +30,22 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                { pathRelative: path.join('@scope1', 'package1') },
-                { pathRelative: path.join('@scope1', 'package2') },
-                { pathRelative: path.join('@scope2', 'deps-only') },
-                { pathRelative: 'package1' },
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope2', 'deps-only'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
               version: '^4.5.6',
             },
@@ -45,10 +58,22 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                { pathRelative: path.join('@scope1', 'package1') },
-                { pathRelative: path.join('@scope1', 'package2') },
-                { pathRelative: path.join('@scope2', 'dev-deps-only') },
-                { pathRelative: 'package1' },
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+                {
+                  pathRelative: path.join('@scope2', 'dev-deps-only'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
               ],
               version: '^7.8.9',
             },
@@ -61,11 +86,23 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                { pathRelative: '' },
-                { pathRelative: path.join('@scope1', 'package1') },
-                { pathRelative: path.join('@scope1', 'package2') },
-                { pathRelative: path.join('@scope2', 'deps-only') },
-                { pathRelative: 'package1' },
+                { pathRelative: '', type: DEPENDENCY_TYPE.devDependencies },
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope2', 'deps-only'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
               version: '1.2.3',
             },
@@ -77,7 +114,12 @@ describe('CDVC', function () {
           name: 'foo1',
           versions: [
             {
-              packages: [{ pathRelative: 'package1' }],
+              packages: [
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '^1.0.0',
             },
           ],
@@ -91,11 +133,20 @@ describe('CDVC', function () {
         versions: [
           {
             packages: [
-              { pathRelative: '' },
-              { pathRelative: path.join('@scope1', 'package1') },
-              { pathRelative: path.join('@scope1', 'package2') },
-              { pathRelative: path.join('@scope2', 'deps-only') },
-              { pathRelative: 'package1' },
+              { pathRelative: '', type: DEPENDENCY_TYPE.devDependencies },
+              {
+                pathRelative: path.join('@scope1', 'package1'),
+                type: DEPENDENCY_TYPE.dependencies,
+              },
+              {
+                pathRelative: path.join('@scope1', 'package2'),
+                type: DEPENDENCY_TYPE.dependencies,
+              },
+              {
+                pathRelative: path.join('@scope2', 'deps-only'),
+                type: DEPENDENCY_TYPE.dependencies,
+              },
+              { pathRelative: 'package1', type: DEPENDENCY_TYPE.dependencies },
             ],
             version: '1.2.3',
           },
@@ -124,8 +175,14 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                { pathRelative: path.join('@scope1', 'package1') },
-                { pathRelative: path.join('@scope1', 'package2') },
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
               version: '^4.5.6',
             },
@@ -137,11 +194,21 @@ describe('CDVC', function () {
           name: 'baz',
           versions: [
             {
-              packages: [{ pathRelative: path.join('@scope1', 'package1') }],
+              packages: [
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+              ],
               version: '^7.8.9',
             },
             {
-              packages: [{ pathRelative: path.join('@scope1', 'package2') }],
+              packages: [
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+              ],
               version: '^8.0.0',
             },
           ],
@@ -153,14 +220,25 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                { pathRelative: '' },
-                { pathRelative: path.join('@scope1', 'package2') },
-                { pathRelative: path.join('@scope1', 'package3') },
+                { pathRelative: '', type: DEPENDENCY_TYPE.devDependencies },
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope1', 'package3'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
               version: '1.2.0',
             },
             {
-              packages: [{ pathRelative: path.join('@scope1', 'package1') }],
+              packages: [
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '1.3.0',
             },
           ],
@@ -187,11 +265,21 @@ describe('CDVC', function () {
             name: 'baz',
             versions: [
               {
-                packages: [{ pathRelative: path.join('@scope1', 'package1') }],
+                packages: [
+                  {
+                    pathRelative: path.join('@scope1', 'package1'),
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
+                ],
                 version: '^7.8.9',
               },
               {
-                packages: [{ pathRelative: path.join('@scope1', 'package2') }],
+                packages: [
+                  {
+                    pathRelative: path.join('@scope1', 'package2'),
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
+                ],
                 version: '^8.0.0',
               },
             ],
@@ -202,7 +290,9 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  { pathRelative: '', type: DEPENDENCY_TYPE.devDependencies },
+                ],
                 version: '1.2.0',
               },
             ],
@@ -229,8 +319,14 @@ describe('CDVC', function () {
             versions: [
               {
                 packages: [
-                  { pathRelative: path.join('@scope1', 'package1') },
-                  { pathRelative: path.join('@scope1', 'package2') },
+                  {
+                    pathRelative: path.join('@scope1', 'package1'),
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
+                  {
+                    pathRelative: path.join('@scope1', 'package2'),
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
                 version: '^4.5.6',
               },
@@ -243,13 +339,24 @@ describe('CDVC', function () {
             versions: [
               {
                 packages: [
-                  { pathRelative: path.join('@scope1', 'package2') },
-                  { pathRelative: path.join('@scope1', 'package3') },
+                  {
+                    pathRelative: path.join('@scope1', 'package2'),
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
+                  {
+                    pathRelative: path.join('@scope1', 'package3'),
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
                 version: '1.2.0',
               },
               {
-                packages: [{ pathRelative: path.join('@scope1', 'package1') }],
+                packages: [
+                  {
+                    pathRelative: path.join('@scope1', 'package1'),
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
+                ],
                 version: '1.3.0',
               },
             ],
@@ -275,7 +382,12 @@ describe('CDVC', function () {
             name: 'bar',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  {
+                    pathRelative: '',
+                    type: DEPENDENCY_TYPE.optionalDependencies,
+                  },
+                ],
                 version: '^1.0.0',
               },
             ],
@@ -286,7 +398,12 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  {
+                    pathRelative: '',
+                    type: DEPENDENCY_TYPE.optionalDependencies,
+                  },
+                ],
                 version: '^2.0.0',
               },
             ],
@@ -363,8 +480,14 @@ describe('CDVC', function () {
                 {
                   version: '^1.0.0',
                   packages: [
-                    { pathRelative: '' },
-                    { pathRelative: 'package1' },
+                    {
+                      pathRelative: '',
+                      type: DEPENDENCY_TYPE.optionalDependencies,
+                    },
+                    {
+                      pathRelative: 'package1',
+                      type: DEPENDENCY_TYPE.dependencies,
+                    },
                   ],
                 },
               ],
@@ -376,15 +499,27 @@ describe('CDVC', function () {
               versions: [
                 {
                   version: '^1.0.0',
-                  packages: [{ pathRelative: '' }],
+                  packages: [
+                    {
+                      pathRelative: '',
+                      type: DEPENDENCY_TYPE.optionalDependencies,
+                    },
+                  ],
                 },
                 {
                   version: '^1.2.0',
-                  packages: [{ pathRelative: '' }],
+                  packages: [
+                    { pathRelative: '', type: DEPENDENCY_TYPE.devDependencies },
+                  ],
                 },
                 {
                   version: '^2.0.0',
-                  packages: [{ pathRelative: 'package1' }],
+                  packages: [
+                    {
+                      pathRelative: 'package1',
+                      type: DEPENDENCY_TYPE.dependencies,
+                    },
+                  ],
                 },
               ],
             },
@@ -410,7 +545,9 @@ describe('CDVC', function () {
             name: 'bar',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  { pathRelative: '', type: DEPENDENCY_TYPE.peerDependencies },
+                ],
                 version: '^1.0.0',
               },
             ],
@@ -421,7 +558,9 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  { pathRelative: '', type: DEPENDENCY_TYPE.peerDependencies },
+                ],
                 version: '^2.0.0',
               },
             ],
@@ -503,8 +642,14 @@ describe('CDVC', function () {
                 {
                   version: '^1.0.0',
                   packages: [
-                    { pathRelative: '' },
-                    { pathRelative: 'package1' },
+                    {
+                      pathRelative: '',
+                      type: DEPENDENCY_TYPE.peerDependencies,
+                    },
+                    {
+                      pathRelative: 'package1',
+                      type: DEPENDENCY_TYPE.dependencies,
+                    },
                   ],
                 },
               ],
@@ -516,15 +661,27 @@ describe('CDVC', function () {
               versions: [
                 {
                   version: '^1.0.0',
-                  packages: [{ pathRelative: '' }],
+                  packages: [
+                    {
+                      pathRelative: '',
+                      type: DEPENDENCY_TYPE.peerDependencies,
+                    },
+                  ],
                 },
                 {
                   version: '^1.2.0',
-                  packages: [{ pathRelative: '' }],
+                  packages: [
+                    { pathRelative: '', type: DEPENDENCY_TYPE.devDependencies },
+                  ],
                 },
                 {
                   version: '^2.0.0',
-                  packages: [{ pathRelative: 'package1' }],
+                  packages: [
+                    {
+                      pathRelative: 'package1',
+                      type: DEPENDENCY_TYPE.dependencies,
+                    },
+                  ],
                 },
               ],
             },
@@ -550,7 +707,9 @@ describe('CDVC', function () {
             name: 'bar',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  { pathRelative: '', type: DEPENDENCY_TYPE.resolutions },
+                ],
                 version: '^1.0.0',
               },
             ],
@@ -561,7 +720,9 @@ describe('CDVC', function () {
             name: 'foo',
             versions: [
               {
-                packages: [{ pathRelative: '' }],
+                packages: [
+                  { pathRelative: '', type: DEPENDENCY_TYPE.resolutions },
+                ],
                 version: '^2.0.0',
               },
             ],
@@ -604,8 +765,14 @@ describe('CDVC', function () {
           versions: [
             {
               packages: [
-                { pathRelative: path.join('@scope1', 'package1') },
-                { pathRelative: path.join('@scope1', 'package2') },
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
               version: '^4.5.6',
             },
@@ -617,11 +784,21 @@ describe('CDVC', function () {
           name: 'baz',
           versions: [
             {
-              packages: [{ pathRelative: path.join('@scope1', 'package1') }],
+              packages: [
+                {
+                  pathRelative: path.join('@scope1', 'package1'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+              ],
               version: '^7.8.9',
             },
             {
-              packages: [{ pathRelative: path.join('@scope1', 'package2') }],
+              packages: [
+                {
+                  pathRelative: path.join('@scope1', 'package2'),
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+              ],
               version: '^8.0.0',
             },
           ],
@@ -674,11 +851,21 @@ describe('CDVC', function () {
           name: 'foo',
           versions: [
             {
-              packages: [{ pathRelative: 'package1' }],
+              packages: [
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '^1.0.0',
             },
             {
-              packages: [{ pathRelative: 'package2' }],
+              packages: [
+                {
+                  pathRelative: 'package2',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '*',
             },
           ],
@@ -750,11 +937,21 @@ describe('CDVC', function () {
           name: 'foo',
           versions: [
             {
-              packages: [{ pathRelative: 'package1' }],
+              packages: [
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '^1.0.0',
             },
             {
-              packages: [{ pathRelative: 'package2' }],
+              packages: [
+                {
+                  pathRelative: 'package2',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '1.5.0',
             },
           ],
@@ -822,11 +1019,21 @@ describe('CDVC', function () {
           name: 'foo',
           versions: [
             {
-              packages: [{ pathRelative: 'package1' }],
+              packages: [
+                {
+                  pathRelative: 'package1',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '^1.0.0',
             },
             {
-              packages: [{ pathRelative: 'package2' }],
+              packages: [
+                {
+                  pathRelative: 'package2',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+              ],
               version: '1.5.0',
             },
           ],
@@ -857,6 +1064,65 @@ describe('CDVC', function () {
         actualPackageJson2.dependencies &&
           actualPackageJson2.dependencies['foo'],
       ).toStrictEqual('^1.5.0');
+    });
+  });
+
+  describe('dependency type in Node API', function () {
+    it('records two entries when the same dep appears under two types in one package', function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          workspaces: ['*'],
+          dependencies: {
+            foo: '^1.0.0',
+          },
+          optionalDependencies: {
+            foo: '^1.0.0',
+          },
+        }),
+        package1: {
+          'package.json': JSON.stringify({
+            name: 'package1',
+          }),
+        },
+      });
+
+      try {
+        const cdvc = new CDVC('.');
+        expect(cdvc.getDependency('foo')).toStrictEqual({
+          isFixable: false,
+          isMismatching: false,
+          name: 'foo',
+          versions: [
+            {
+              packages: [
+                {
+                  pathRelative: '',
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  pathRelative: '',
+                  type: DEPENDENCY_TYPE.optionalDependencies,
+                },
+              ],
+              version: '^1.0.0',
+            },
+          ],
+        });
+      } finally {
+        mockFs.restore();
+      }
+    });
+
+    it('omits type for the local workspace package version entry', function () {
+      const cdvc = new CDVC(FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION);
+      const package2 = cdvc.getDependency('package2');
+      const localPackageEntry = package2.versions.find(
+        (version) => version.version === '1.0.0',
+      );
+      expect(localPackageEntry).toStrictEqual({
+        packages: [{ pathRelative: 'package2' }],
+        version: '1.0.0',
+      });
     });
   });
 });

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -18,6 +18,7 @@ import {
   FIXTURE_PATH_VALID_WITH_WORKSPACE_PREFIX,
   FIXTURE_PATH_INCONSISTENT_WITH_WORKSPACE_PREFIX,
 } from '../fixtures/index.js';
+import type { Package } from '../../lib/package.js';
 import { DEPENDENCY_TYPE } from '../../lib/types.js';
 import mockFs from 'mock-fs';
 import { readFileSync } from 'node:fs';
@@ -56,25 +57,31 @@ describe('Utils | dependency-versions', function () {
             {
               version: '^7.8.9',
               packages: [
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_VERSIONS,
-                    '@scope1',
-                    'package1',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_VERSIONS,
+                      '@scope1',
+                      'package1',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
               ],
             },
             {
               version: '^8.0.0',
               packages: [
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_VERSIONS,
-                    '@scope1',
-                    'package2',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_VERSIONS,
+                      '@scope1',
+                      'package2',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
               ],
             },
           ],
@@ -85,35 +92,47 @@ describe('Utils | dependency-versions', function () {
             {
               version: '1.2.0',
               packages: [
-                expect.objectContaining({
-                  path: join(FIXTURE_PATH_INCONSISTENT_VERSIONS),
-                }),
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_VERSIONS,
-                    '@scope1',
-                    'package2',
-                  ),
-                }),
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_VERSIONS,
-                    '@scope1',
-                    'package3',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(FIXTURE_PATH_INCONSISTENT_VERSIONS),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_VERSIONS,
+                      '@scope1',
+                      'package2',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_VERSIONS,
+                      '@scope1',
+                      'package3',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
             },
             {
               version: '1.3.0',
               packages: [
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_VERSIONS,
-                    '@scope1',
-                    'package1',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_VERSIONS,
+                      '@scope1',
+                      'package1',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
             },
           ],
@@ -161,23 +180,29 @@ describe('Utils | dependency-versions', function () {
             {
               version: '^0.0.0',
               packages: [
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION,
-                    'package1',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION,
+                      'package1',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
             },
             {
               version: '1.0.0',
               packages: [
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION,
-                    'package2',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_LOCAL_PACKAGE_VERSION,
+                      'package2',
+                    ),
+                  }) as Package,
+                  type: undefined,
+                },
               ],
             },
           ],
@@ -200,25 +225,34 @@ describe('Utils | dependency-versions', function () {
             {
               version: '^1.2.0',
               packages: [
-                expect.objectContaining({
-                  path: FIXTURE_PATH_RESOLUTIONS,
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: FIXTURE_PATH_RESOLUTIONS,
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.devDependencies,
+                },
               ],
             },
             {
               version: '1.3.0',
               packages: [
-                expect.objectContaining({
-                  path: join(FIXTURE_PATH_RESOLUTIONS, 'package1'),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(FIXTURE_PATH_RESOLUTIONS, 'package1'),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
             },
             {
               version: '^2.0.0',
               packages: [
-                expect.objectContaining({
-                  path: FIXTURE_PATH_RESOLUTIONS,
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: FIXTURE_PATH_RESOLUTIONS,
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.resolutions,
+                },
               ],
             },
           ],
@@ -263,20 +297,26 @@ describe('Utils | dependency-versions', function () {
             {
               version: 'workspace:*',
               packages: [
-                expect.objectContaining({
-                  path: FIXTURE_PATH_INCONSISTENT_WITH_WORKSPACE_PREFIX,
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: FIXTURE_PATH_INCONSISTENT_WITH_WORKSPACE_PREFIX,
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
             },
             {
               version: 'workspace:^',
               packages: [
-                expect.objectContaining({
-                  path: join(
-                    FIXTURE_PATH_INCONSISTENT_WITH_WORKSPACE_PREFIX,
-                    'package2',
-                  ),
-                }),
+                {
+                  package: expect.objectContaining({
+                    path: join(
+                      FIXTURE_PATH_INCONSISTENT_WITH_WORKSPACE_PREFIX,
+                      'package2',
+                    ),
+                  }) as Package,
+                  type: DEPENDENCY_TYPE.dependencies,
+                },
               ],
             },
           ],
@@ -524,17 +564,23 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '^3.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package1'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package1'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
               {
                 version: 'invalidVersion',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package2'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package2'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
             ],
@@ -548,17 +594,23 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '1.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package2'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package2'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
                 ],
               },
               {
                 version: '1.0.1',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package1'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package1'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
                 ],
               },
             ],
@@ -569,17 +621,23 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '5.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package1'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package1'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
               {
                 version: '~5.5.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package2'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package2'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
             ],
@@ -590,20 +648,29 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '^1.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: '.',
-                  }),
-                  expect.objectContaining({
-                    path: join('@scope1', 'package1'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: '.',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package1'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
               {
                 version: '^2.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package2'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package2'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
             ],
@@ -614,17 +681,23 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '^4.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package2'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package2'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
                 ],
               },
               {
                 version: '^4.1.0',
                 packages: [
-                  expect.objectContaining({
-                    path: join('@scope1', 'package1'),
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: join('@scope1', 'package1'),
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
                 ],
               },
             ],
@@ -723,15 +796,36 @@ describe('Utils | dependency-versions', function () {
             versions: [
               {
                 version: '^0.0.0',
-                packages: [expect.objectContaining({ path: 'package3' })],
+                packages: [
+                  {
+                    package: expect.objectContaining({
+                      path: 'package3',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
+                ],
               },
               {
                 version: '1.0.0',
-                packages: [expect.objectContaining({ path: 'package1' })],
+                packages: [
+                  {
+                    package: expect.objectContaining({
+                      path: 'package1',
+                    }) as Package,
+                    type: undefined,
+                  },
+                ],
               },
               {
                 version: '^2.0.0',
-                packages: [expect.objectContaining({ path: 'package2' })],
+                packages: [
+                  {
+                    package: expect.objectContaining({
+                      path: 'package2',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
+                ],
               },
             ],
           },
@@ -745,17 +839,23 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '^1.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: 'package1',
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: 'package1',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
               {
                 version: '2.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: 'package2',
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: 'package2',
+                    }) as Package,
+                    type: undefined,
+                  },
                 ],
               },
             ],
@@ -837,25 +937,34 @@ describe('Utils | dependency-versions', function () {
               {
                 version: '^1.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: '.',
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: '.',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.resolutions,
+                  },
                 ],
               },
               {
                 version: '^1.2.0',
                 packages: [
-                  expect.objectContaining({
-                    path: '.',
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: '.',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.devDependencies,
+                  },
                 ],
               },
               {
                 version: '^2.0.0',
                 packages: [
-                  expect.objectContaining({
-                    path: 'package1',
-                  }),
+                  {
+                    package: expect.objectContaining({
+                      path: 'package1',
+                    }) as Package,
+                    type: DEPENDENCY_TYPE.dependencies,
+                  },
                 ],
               },
             ],


### PR DESCRIPTION
## Summary
- Adds `type` to each `versions[].packages` entry in the Node API so callers can tell whether a usage is a dependency, devDependency, peerDependency, etc.
- Local workspace package version entries omit `type` (no dependency type applies).
- Re-exports `DependencyType` / `DEPENDENCY_TYPE` from the public package entrypoint.
- CLI table output is unchanged.

Closes #614

## Test plan
- [x] `npm test` (100% coverage)
- [x] `npm run build`
- [x] `npm run lint` (js/docs)
- [x] CLI against `test/fixtures/testing-output` — table output unchanged (exit 1 as before due to mismatches)
- [x] Targeted tests for dual dep types in one package and local-package entry without `type`


Made with [Cursor](https://cursor.com)