### PR TITLE
refactor: Decide fix targets once and deepen dependency inventory

### DIFF
--- a/lib/cdvc.ts
+++ b/lib/cdvc.ts
@@ -10,6 +10,8 @@ type Dependency = {
   name: string;
   isFixable: boolean;
   isMismatching: boolean;
+  /** Version that `--fix` would write; set only when fixable. */
+  fixedVersion?: string;
   versions: readonly {
     version: string;
     packages: readonly { pathRelative: string }[];
@@ -61,6 +63,9 @@ export class CDVC {
       name,
       isFixable: dep.isFixable,
       isMismatching: dep.isMismatching,
+      ...(dep.fixedVersion === undefined
+        ? {}
+        : { fixedVersion: dep.fixedVersion }),
       versions: dep.versions.map((version) => ({
         version: version.version,
         packages: version.packages.map((package_) => ({

--- a/lib/check.ts
+++ b/lib/check.ts
@@ -1,9 +1,4 @@
-import {
-  calculateVersionsForEachDependency,
-  calculateDependenciesAndVersions,
-  filterOutIgnoredDependencies,
-  fixVersionsMismatching,
-} from './dependency-versions.js';
+import { buildDependencies } from './dependency-versions.js';
 import { DEPENDENCY_TYPE } from './types.js';
 import type { Dependencies, Options } from './types.js';
 import { getPackages } from './workspace.js';
@@ -57,7 +52,6 @@ export function check(
         : DEFAULT_DEP_TYPES,
   };
 
-  // Calculate.
   const packages = getPackages(
     path,
     optionsWithDefaults.ignorePackage,
@@ -66,54 +60,14 @@ export function check(
     optionsWithDefaults.ignorePathPattern.map((s) => new RegExp(s)),
   );
 
-  const dependencies = calculateVersionsForEachDependency(
-    packages,
-    optionsWithDefaults.depType.map((dt) => DEPENDENCY_TYPE[dt]), // Convert string to enum.
-  );
-  const dependenciesAndVersions =
-    calculateDependenciesAndVersions(dependencies);
-  const dependenciesAndVersionsWithMismatches = dependenciesAndVersions.filter(
-    ({ versions }) => versions.length > 1,
-  );
-
-  // Information about all dependencies.
-  const dependenciesAndVersionsWithoutIgnored = filterOutIgnoredDependencies(
-    dependenciesAndVersions,
-    optionsWithDefaults.ignoreDep,
-    optionsWithDefaults.ignoreDepPattern.map((s) => new RegExp(s)),
-  );
-
-  // Information about mismatches.
-  const dependenciesAndVersionsMismatchesWithoutIgnored =
-    filterOutIgnoredDependencies(
-      dependenciesAndVersionsWithMismatches,
-      optionsWithDefaults.ignoreDep,
-      optionsWithDefaults.ignoreDepPattern.map((s) => new RegExp(s)),
-    );
-  const resultsAfterFix = fixVersionsMismatching(
-    packages,
-    dependenciesAndVersionsMismatchesWithoutIgnored,
-    !optionsWithDefaults.fix, // Do dry-run if not fixing.
-  );
-  const versionsMismatchingFixable = resultsAfterFix.fixable;
-
   return {
-    // Information about all dependencies.
-    dependencies: Object.fromEntries(
-      dependenciesAndVersionsWithoutIgnored.map(({ dependency, versions }) => {
-        return [
-          dependency,
-          {
-            isFixable: versionsMismatchingFixable.some(
-              (dep) => dep.dependency === dependency,
-            ),
-            isMismatching: dependenciesAndVersionsMismatchesWithoutIgnored.some(
-              (dep) => dep.dependency === dependency,
-            ),
-            versions,
-          },
-        ];
-      }),
-    ),
+    dependencies: buildDependencies(packages, {
+      depType: optionsWithDefaults.depType.map((dt) => DEPENDENCY_TYPE[dt]),
+      ignoreDep: optionsWithDefaults.ignoreDep,
+      ignoreDepPattern: optionsWithDefaults.ignoreDepPattern.map(
+        (s) => new RegExp(s),
+      ),
+      fix: optionsWithDefaults.fix,
+    }),
   };
 }

--- a/lib/dependency-versions.ts
+++ b/lib/dependency-versions.ts
@@ -9,8 +9,7 @@ import {
   getIncreasedLatestVersion,
   versionRangeToRange,
 } from './semver.js';
-import { DEPENDENCY_TYPE } from './types.js';
-import type { DependencyType } from './types.js';
+import type { Dependencies, DependencyType } from './types.js';
 
 /** A version of a dependency seen in a particular package. */
 type VersionSeen = {
@@ -31,6 +30,12 @@ type DependencyAndVersions = {
     version: string;
     packages: readonly Package[];
   }[];
+};
+
+/** A mismatch with its resolved fix target, if any. */
+type MismatchWithFix = DependencyAndVersions & {
+  /** Version to write; absent when not fixable. */
+  fixedVersion?: string;
 };
 
 /**
@@ -236,6 +241,47 @@ export function filterOutIgnoredDependencies(
   return mismatchingVersions;
 }
 
+/**
+ * Decides the single version a mismatch should be fixed to, or `undefined` if not fixable.
+ * Local-package caps and range-type reattachment live here so write and summary share one decision.
+ */
+export function resolveFixedVersion(
+  mismatchingVersion: DependencyAndVersions,
+  packages: readonly Package[],
+): string | undefined {
+  const versions = mismatchingVersion.versions.map((object) => object.version);
+  let fixedVersion;
+  try {
+    fixedVersion = getIncreasedLatestVersion(versions);
+  } catch {
+    return undefined;
+  }
+
+  // If this dependency is from a local package and the version we want to fix to is higher than the actual package version, skip it.
+  const localPackage = packages.find(
+    (package_) => package_.name === mismatchingVersion.dependency,
+  );
+  if (
+    localPackage &&
+    localPackage.packageJson.version &&
+    compareVersionRanges(fixedVersion, localPackage.packageJson.version) > 0
+  ) {
+    return undefined;
+  }
+
+  if (localPackage && localPackage.packageJson.version === fixedVersion) {
+    // When fixing to the version of a local package, don't just use the bare package version, but include the highest range type we have seen.
+    const highestRangeTypeSeen = getHighestRangeType(
+      versions.map((versionRange) => versionRangeToRange(versionRange)),
+    );
+    fixedVersion = `${highestRangeTypeSeen}${String(
+      semver.coerce(fixedVersion),
+    )}`;
+  }
+
+  return fixedVersion;
+}
+
 function writeDependencyVersion(
   packageJsonPath: string,
   packageJsonEndsInNewline: boolean,
@@ -258,84 +304,63 @@ function writeDependencyVersion(
   );
 }
 
+function applyFixedVersion(
+  packages: readonly Package[],
+  dependency: string,
+  fixedVersion: string,
+  depType: readonly DependencyType[],
+  dryrun: boolean,
+): boolean {
+  let isFixed = false;
+  for (const package_ of packages) {
+    for (const type of depType) {
+      const currentVersion = package_.packageJson[type]?.[dependency];
+      if (currentVersion && currentVersion !== fixedVersion) {
+        if (!dryrun) {
+          writeDependencyVersion(
+            package_.pathPackageJson,
+            package_.packageJsonEndsInNewline,
+            type,
+            dependency,
+            fixedVersion,
+          );
+        }
+        isFixed = true;
+      }
+    }
+  }
+  return isFixed;
+}
+
 export function fixVersionsMismatching(
   packages: readonly Package[],
   mismatchingVersions: readonly DependencyAndVersions[],
   dryrun = false,
+  depType: readonly DependencyType[] = DEFAULT_DEP_TYPES,
 ): {
-  fixable: readonly DependencyAndVersions[];
+  fixable: readonly MismatchWithFix[];
   notFixable: readonly DependencyAndVersions[];
 } {
-  const fixable: DependencyAndVersions[] = [];
+  const fixable: MismatchWithFix[] = [];
   const notFixable: DependencyAndVersions[] = [];
   // Loop through each dependency that has a mismatching versions.
   for (const mismatchingVersion of mismatchingVersions) {
-    // Decide what version we should fix to.
-    const versions = mismatchingVersion.versions.map(
-      (object) => object.version,
-    );
-    let fixedVersion;
-    try {
-      fixedVersion = getIncreasedLatestVersion(versions);
-    } catch {
-      // Skip this dependency.
+    const fixedVersion = resolveFixedVersion(mismatchingVersion, packages);
+    if (fixedVersion === undefined) {
       notFixable.push(mismatchingVersion);
       continue;
     }
 
-    // If this dependency is from a local package and the version we want to fix to is higher than the actual package version, skip it.
-    const localPackage = packages.find(
-      (package_) => package_.name === mismatchingVersion.dependency,
+    const isFixed = applyFixedVersion(
+      packages,
+      mismatchingVersion.dependency,
+      fixedVersion,
+      depType,
+      dryrun,
     );
-    if (
-      localPackage &&
-      localPackage.packageJson.version &&
-      compareVersionRanges(fixedVersion, localPackage.packageJson.version) > 0
-    ) {
-      // Skip this dependency.
-      notFixable.push(mismatchingVersion);
-      continue;
-    }
-
-    if (localPackage && localPackage.packageJson.version === fixedVersion) {
-      // When fixing to the version of a local package, don't just use the bare package version, but include the highest range type we have seen.
-      const highestRangeTypeSeen = getHighestRangeType(
-        versions.map((versionRange) => versionRangeToRange(versionRange)),
-      );
-      fixedVersion = `${highestRangeTypeSeen}${String(
-        semver.coerce(fixedVersion),
-      )}`;
-    }
-
-    // Update the dependency version in each package.json.
-    let isFixed = false;
-    for (const package_ of packages) {
-      for (const type of [
-        DEPENDENCY_TYPE.devDependencies,
-        DEPENDENCY_TYPE.dependencies,
-        DEPENDENCY_TYPE.optionalDependencies,
-        DEPENDENCY_TYPE.peerDependencies,
-        DEPENDENCY_TYPE.resolutions,
-      ]) {
-        const currentVersion =
-          package_.packageJson[type]?.[mismatchingVersion.dependency];
-        if (currentVersion && currentVersion !== fixedVersion) {
-          if (!dryrun) {
-            writeDependencyVersion(
-              package_.pathPackageJson,
-              package_.packageJsonEndsInNewline,
-              type,
-              mismatchingVersion.dependency,
-              fixedVersion,
-            );
-          }
-          isFixed = true;
-        }
-      }
-    }
 
     if (isFixed) {
-      fixable.push(mismatchingVersion);
+      fixable.push({ ...mismatchingVersion, fixedVersion });
     }
   }
 
@@ -343,4 +368,72 @@ export function fixVersionsMismatching(
     fixable,
     notFixable,
   };
+}
+
+/**
+ * Build the full dependency inventory: collect, detect mismatches, ignore, resolve fix targets, optionally write.
+ * One deep interface for the check pipeline.
+ */
+export function buildDependencies(
+  packages: readonly Package[],
+  options: {
+    depType: readonly DependencyType[];
+    ignoreDep: readonly string[];
+    ignoreDepPattern: readonly RegExp[];
+    fix: boolean;
+  },
+): Dependencies {
+  const dependencyVersions = calculateVersionsForEachDependency(
+    packages,
+    options.depType,
+  );
+  const dependenciesAndVersions =
+    calculateDependenciesAndVersions(dependencyVersions);
+  const dependenciesAndVersionsWithMismatches = dependenciesAndVersions.filter(
+    ({ versions }) => versions.length > 1,
+  );
+
+  const dependenciesAndVersionsWithoutIgnored = filterOutIgnoredDependencies(
+    dependenciesAndVersions,
+    options.ignoreDep,
+    options.ignoreDepPattern,
+  );
+
+  const dependenciesAndVersionsMismatchesWithoutIgnored =
+    filterOutIgnoredDependencies(
+      dependenciesAndVersionsWithMismatches,
+      options.ignoreDep,
+      options.ignoreDepPattern,
+    );
+
+  const resultsAfterFix = fixVersionsMismatching(
+    packages,
+    dependenciesAndVersionsMismatchesWithoutIgnored,
+    !options.fix, // Do dry-run if not fixing.
+    options.depType,
+  );
+
+  const fixableByName = new Map(
+    resultsAfterFix.fixable.map((dep) => [dep.dependency, dep.fixedVersion]),
+  );
+  const mismatchingNames = new Set(
+    dependenciesAndVersionsMismatchesWithoutIgnored.map(
+      (dep) => dep.dependency,
+    ),
+  );
+
+  return Object.fromEntries(
+    dependenciesAndVersionsWithoutIgnored.map(({ dependency, versions }) => {
+      const fixedVersion = fixableByName.get(dependency);
+      return [
+        dependency,
+        {
+          isFixable: fixedVersion !== undefined,
+          isMismatching: mismatchingNames.has(dependency),
+          ...(fixedVersion === undefined ? {} : { fixedVersion }),
+          versions,
+        },
+      ];
+    }),
+  );
 }

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,16 +1,18 @@
 import { styleText } from 'node:util';
 import { table } from 'table';
-import {
-  compareVersionRangesSafe,
-  getIncreasedLatestVersion,
-} from './semver.js';
+import { compareVersionRangesSafe } from './semver.js';
 import type { Dependencies } from './types.js';
 
 /** Extracts the mismatching dependencies along with the versions seen of each. */
 function getMismatchingVersions(dependencies: Dependencies) {
   return Object.entries(dependencies)
     .filter(([, value]) => value.isMismatching)
-    .map(([dependency, value]) => ({ dependency, versions: value.versions }));
+    .map(([dependency, value]) => ({
+      dependency,
+      versions: value.versions,
+      fixedVersion: value.fixedVersion,
+      isFixable: value.isFixable,
+    }));
 }
 
 /**
@@ -77,34 +79,31 @@ export function dependenciesToMismatchSummary(
 
 /**
  * Returns a summary of the mismatching dependency versions that were fixed.
+ * Uses the fix targets already decided during check (does not recompute versions).
  */
 export function dependenciesToFixedSummary(dependencies: Dependencies): string {
-  const mismatchingDependencyVersions = getMismatchingVersions(dependencies);
-
-  if (mismatchingDependencyVersions.length === 0) {
-    throw new Error('No fixes to output.');
-  }
-
-  const dependenciesAndFixedVersions = mismatchingDependencyVersions
+  const fixedDependencies = getMismatchingVersions(dependencies)
     .flatMap((mismatchingVersion) => {
-      let version;
-      try {
-        version = getIncreasedLatestVersion(
-          mismatchingVersion.versions.map((v) => v.version),
-        );
-      } catch {
-        return []; // Ignore this dependency since unable to get the version that we would have fixed it to.
+      if (
+        !mismatchingVersion.isFixable ||
+        mismatchingVersion.fixedVersion === undefined
+      ) {
+        return [];
       }
       return {
         dependency: mismatchingVersion.dependency,
-        version,
+        version: mismatchingVersion.fixedVersion,
       };
     })
     .toSorted((a, b) => a.dependency.localeCompare(b.dependency));
 
-  return `Fixed versions for ${String(dependenciesAndFixedVersions.length)} ${
-    dependenciesAndFixedVersions.length === 1 ? 'dependency' : 'dependencies'
-  }: ${dependenciesAndFixedVersions
+  if (fixedDependencies.length === 0) {
+    throw new Error('No fixes to output.');
+  }
+
+  return `Fixed versions for ${String(fixedDependencies.length)} ${
+    fixedDependencies.length === 1 ? 'dependency' : 'dependencies'
+  }: ${fixedDependencies
     .map((object) => `${object.dependency}@${object.version}`)
     .join(', ')}`;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,6 +6,8 @@ export type Dependencies = Record<
   {
     isFixable: boolean;
     isMismatching: boolean;
+    /** Version that `--fix` would write; set only when fixable. */
+    fixedVersion?: string;
     versions: readonly {
       version: string;
       packages: readonly Package[];

--- a/test/lib/cdvc-test.ts
+++ b/test/lib/cdvc-test.ts
@@ -132,6 +132,7 @@ describe('CDVC', function () {
           ],
         },
         {
+          fixedVersion: '^8.0.0',
           isFixable: true,
           isMismatching: true,
           name: 'baz',
@@ -147,6 +148,7 @@ describe('CDVC', function () {
           ],
         },
         {
+          fixedVersion: '1.3.0',
           isFixable: true,
           isMismatching: true,
           name: 'foo',
@@ -182,6 +184,7 @@ describe('CDVC', function () {
         expect(cdvc.hasMismatchingDependenciesNotFixable).toBe(false);
         expect(dependencies).toStrictEqual([
           {
+            fixedVersion: '^8.0.0',
             isFixable: true,
             isMismatching: true,
             name: 'baz',
@@ -237,6 +240,7 @@ describe('CDVC', function () {
             ],
           },
           {
+            fixedVersion: '1.3.0',
             isFixable: true,
             isMismatching: true,
             name: 'foo',
@@ -371,6 +375,7 @@ describe('CDVC', function () {
             },
             {
               name: 'foo',
+              fixedVersion: '^2.0.0',
               isFixable: true,
               isMismatching: true,
               versions: [
@@ -511,6 +516,7 @@ describe('CDVC', function () {
             },
             {
               name: 'foo',
+              fixedVersion: '^2.0.0',
               isFixable: true,
               isMismatching: true,
               versions: [
@@ -612,6 +618,7 @@ describe('CDVC', function () {
           ],
         },
         {
+          fixedVersion: '^8.0.0',
           isFixable: true,
           isMismatching: true,
           name: 'baz',
@@ -745,6 +752,7 @@ describe('CDVC', function () {
 
       expect(cdvc.getDependencies()).toStrictEqual([
         {
+          fixedVersion: '^1.5.0',
           isFixable: true,
           isMismatching: true,
           name: 'foo',
@@ -817,6 +825,7 @@ describe('CDVC', function () {
 
       expect(cdvc.getDependencies()).toStrictEqual([
         {
+          fixedVersion: '^1.5.0',
           isFixable: true,
           isMismatching: true,
           name: 'foo',

--- a/test/lib/dependency-versions-test.ts
+++ b/test/lib/dependency-versions-test.ts
@@ -544,6 +544,7 @@ describe('Utils | dependency-versions', function () {
         expect(fixable).toStrictEqual([
           {
             dependency: '@types/one',
+            fixedVersion: '1.0.1',
             versions: [
               {
                 version: '1.0.0',
@@ -565,6 +566,7 @@ describe('Utils | dependency-versions', function () {
           },
           {
             dependency: 'a.b.c',
+            fixedVersion: '~5.5.0',
             versions: [
               {
                 version: '5.0.0',
@@ -586,6 +588,7 @@ describe('Utils | dependency-versions', function () {
           },
           {
             dependency: 'foo',
+            fixedVersion: '^2.0.0',
             versions: [
               {
                 version: '^1.0.0',
@@ -610,6 +613,7 @@ describe('Utils | dependency-versions', function () {
           },
           {
             dependency: 'one.two.three',
+            fixedVersion: '^4.1.0',
             versions: [
               {
                 version: '^4.0.0',
@@ -741,6 +745,7 @@ describe('Utils | dependency-versions', function () {
           {
             // Fixable since updated to actual version of this local package.
             dependency: 'package2',
+            fixedVersion: '^2.0.0',
             versions: [
               {
                 version: '^1.0.0',
@@ -833,6 +838,7 @@ describe('Utils | dependency-versions', function () {
         expect(fixable).toStrictEqual([
           {
             dependency: 'foo',
+            fixedVersion: '^2.0.0',
             versions: [
               {
                 version: '^1.0.0',


### PR DESCRIPTION
## Summary

- **Single fix-target decision:** extract `resolveFixedVersion` so write path and fixed summary no longer recompute versions independently (local-package caps + range-type reattachment stay in one place).
- **Deepen inventory:** `buildDependencies` owns collect → mismatch → ignore → resolve → optional write; `check` is thin options/workspace glue.
- **Public `fixedVersion`:** exposed on `Dependencies` and `CDVC.getDependency()` when fixable; output formats already-decided targets (drops `getIncreasedLatestVersion` from `output.ts`).
- **depType alignment:** fix walks the same dependency sections as record (defaults still exclude peers).

## Test plan

- [x] `npm test` (90 tests, 100% coverage)
- [x] `npm run lint` / `lint:types` / `build`
- [ ] Spot-check CLI: mismatch summary, `--fix` summary, local-package not-fixable case
- [ ] Confirm `--dep-type` only fixes the selected sections